### PR TITLE
[4주차] API 구현

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -10,6 +10,7 @@ erDiagram
     MEMBER_QUEUE {
         bigint id PK
         bigint member_id FK
+        bigint concert_id FK
         varchar(255) token "대기열 토큰"
         varchar(10) status "대기열 상태(WAIT, ACTIVE, EXPIRED)"
         LocalDateTime expired_at "대기열 만료 시간"

--- a/src/main/java/com/hanghae/concert/api/common/config/SwaggerConfig.java
+++ b/src/main/java/com/hanghae/concert/api/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.hanghae.concert.api.config;
+package com.hanghae.concert.api.common.config;
 
 import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.info.*;

--- a/src/main/java/com/hanghae/concert/api/common/exception/NotFoundException.java
+++ b/src/main/java/com/hanghae/concert/api/common/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.hanghae.concert.api.common.exception;
+
+public abstract class NotFoundException extends BusinessException {
+
+    public NotFoundException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/hanghae/concert/api/concert/ConcertController.java
+++ b/src/main/java/com/hanghae/concert/api/concert/ConcertController.java
@@ -2,7 +2,6 @@ package com.hanghae.concert.api.concert;
 
 import com.hanghae.concert.api.concert.dto.request.*;
 import com.hanghae.concert.api.concert.dto.response.*;
-import io.swagger.v3.oas.annotations.*;
 import jakarta.validation.*;
 import lombok.*;
 import org.springframework.http.*;
@@ -14,16 +13,15 @@ import java.util.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/concerts")
-public class ConcertController {
+public class ConcertController implements IConcertController {
 
     /**
      * 예약 가능 날짜 조회
      */
-    @Operation(summary = "예약 가능 날짜 조회", description = "특정 콘서트의 예약 가능한 날짜를 조회합니다.")
+    @Override
     @GetMapping("/{concertId}/schedules")
     public ResponseEntity<List<ConcertAvailableDateResponse>> getConcertSchedules(
-            @Parameter(description = "JWT 인증 토큰", required = true)
-            @RequestHeader(name = "Authorization") String token
+            @RequestHeader String token
     ) {
         List<ConcertAvailableDateResponse> responses = List.of(
                 new ConcertAvailableDateResponse(1L, LocalDateTime.now()),
@@ -37,14 +35,11 @@ public class ConcertController {
     /**
      * 예약 가능 좌석 조회
      */
-    @Operation(summary = "예약 가능 좌석 조회", description = "예약 가능한 좌석을 조회합니다.")
+    @Override
     @GetMapping("/schedule/{concertScheduleId}/seats")
     public ResponseEntity<List<ConcertAvailableSeatResponse>> getConcertSeats(
-            @Parameter(description = "JWT 인증 토큰", required = true)
-            @RequestHeader(name = "Authorization") String token,
-
-            @Parameter(description = "콘서트 스케쥴 ID", required = true)
-            @PathVariable(name = "concertScheduleId") Long concertScheduleId
+            @RequestHeader String token,
+            @PathVariable Long concertScheduleId
     ) {
         List<ConcertAvailableSeatResponse> responses = List.of(
                 new ConcertAvailableSeatResponse(1L, 1L, 1),
@@ -58,17 +53,12 @@ public class ConcertController {
     /**
      * 좌석 예약
      */
-    @Operation(summary = "좌석 예약", description = "좌석을 예약합니다.")
+    @Override
     @PostMapping("{concertScheduleId}/seat/{concertSeatId}")
     public ResponseEntity<Void> reserveConcert(
-            @Parameter(description = "JWT 인증 토큰", required = true)
-            @RequestHeader(name = "Authorization") String token,
-
-            @Parameter(description = "콘서트 스케쥴 ID", required = true)
-            @PathVariable(name = "concertScheduleId") Long concertScheduleId,
-
-            @Parameter(description = "콘서트 좌석 ID", required = true)
-            @PathVariable(name = "concertSeatId") Long concertSeatId
+            @RequestHeader String token,
+            @PathVariable Long concertScheduleId,
+            @PathVariable Long concertSeatId
     ) {
         return ResponseEntity.ok().build();
     }
@@ -76,13 +66,10 @@ public class ConcertController {
     /**
      * 콘서트 좌석 결제
      */
-    @Operation(summary = "콘서트 좌석 결제", description = "예약한 콘서트 좌석에 대한 결제를 진행합니다.")
+    @Override
     @PostMapping("/pay/{reservationId}")
     public ResponseEntity<ReservationPayResponse> payConcert(
-            @Parameter(description = "JWT 인증 토큰", required = true)
-            @RequestHeader(name = "Authorization") String token,
-
-            @Parameter(description = "결제에 필요한 요청 데이터", required = true)
+            @RequestHeader String token,
             @RequestBody @Valid ReservationSeatRequest request
     ) {
         return ResponseEntity.ok(

--- a/src/main/java/com/hanghae/concert/api/concert/IConcertController.java
+++ b/src/main/java/com/hanghae/concert/api/concert/IConcertController.java
@@ -1,0 +1,60 @@
+package com.hanghae.concert.api.concert;
+
+import com.hanghae.concert.api.concert.dto.request.*;
+import com.hanghae.concert.api.concert.dto.response.*;
+import io.swagger.v3.oas.annotations.*;
+import jakarta.validation.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+public interface IConcertController {
+
+    /**
+     * 예약 가능 날짜 조회
+     */
+    @Operation(summary = "예약 가능 날짜 조회", description = "특정 콘서트의 예약 가능한 날짜를 조회합니다.")
+    ResponseEntity<List<ConcertAvailableDateResponse>> getConcertSchedules(
+            @Parameter(description = "JWT 인증 토큰", required = true)
+            @RequestHeader(name = "Authorization") String token
+    );
+
+    /**
+     * 예약 가능 좌석 조회
+     */
+    @Operation(summary = "예약 가능 좌석 조회", description = "예약 가능한 좌석을 조회합니다.")
+    @GetMapping("/schedule/{concertScheduleId}/seats")
+    ResponseEntity<List<ConcertAvailableSeatResponse>> getConcertSeats(
+            @Parameter(description = "JWT 인증 토큰", required = true)
+            @RequestHeader(name = "Authorization") String token,
+            @Parameter(description = "콘서트 스케쥴 ID", required = true)
+            @PathVariable(name = "concertScheduleId") Long concertScheduleId
+    );
+
+    /**
+     * 좌석 예약
+     */
+    @Operation(summary = "좌석 예약", description = "좌석을 예약합니다.")
+    @PostMapping("{concertScheduleId}/seat/{concertSeatId}")
+    ResponseEntity<Void> reserveConcert(
+            @Parameter(description = "JWT 인증 토큰", required = true)
+            @RequestHeader(name = "Authorization") String token,
+            @Parameter(description = "콘서트 스케쥴 ID", required = true)
+            @PathVariable(name = "concertScheduleId") Long concertScheduleId,
+            @Parameter(description = "콘서트 좌석 ID", required = true)
+            @PathVariable(name = "concertSeatId") Long concertSeatId
+    );
+
+    /**
+     * 콘서트 좌석 결제
+     */
+    @Operation(summary = "콘서트 좌석 결제", description = "예약한 콘서트 좌석에 대한 결제를 진행합니다.")
+    @PostMapping("/pay/{reservationId}")
+    ResponseEntity<ReservationPayResponse> payConcert(
+            @Parameter(description = "JWT 인증 토큰", required = true)
+            @RequestHeader(name = "Authorization") String token,
+            @Parameter(description = "결제에 필요한 요청 데이터", required = true)
+            @RequestBody @Valid ReservationSeatRequest request
+    );
+}

--- a/src/main/java/com/hanghae/concert/api/member/IMemberController.java
+++ b/src/main/java/com/hanghae/concert/api/member/IMemberController.java
@@ -1,0 +1,31 @@
+package com.hanghae.concert.api.member;
+
+import com.hanghae.concert.api.member.dto.request.*;
+import com.hanghae.concert.api.member.dto.response.*;
+import io.swagger.v3.oas.annotations.*;
+import jakarta.validation.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+public interface IMemberController {
+
+    /**
+     * 특정 유저 조회(잔액 조회)
+     */
+    @Operation(summary = "특정 유저 조회", description = "특정 회원의 잔액 정보를 조회합니다.")
+    ResponseEntity<MemberResponse> getMember(
+            @Parameter(description = "JWT 인증 토큰", required = true)
+            @RequestHeader(name = "Authorization") String token
+    );
+
+    /**
+     * 특정 유저 충전
+     */
+    @Operation(summary = "특정 유저 충전", description = "특정 회원의 잔액을 충전합니다.")
+    ResponseEntity<MemberResponse> chargeBalance(
+            @Parameter(description = "JWT 인증 토큰", required = true)
+            @RequestHeader(name = "Authorization") String token,
+            @Parameter(description = "충전할 금액 정보", required = true)
+            @RequestBody @Valid MemberChargeRequest request
+    );
+}

--- a/src/main/java/com/hanghae/concert/api/member/MemberController.java
+++ b/src/main/java/com/hanghae/concert/api/member/MemberController.java
@@ -2,7 +2,6 @@ package com.hanghae.concert.api.member;
 
 import com.hanghae.concert.api.member.dto.request.*;
 import com.hanghae.concert.api.member.dto.response.*;
-import io.swagger.v3.oas.annotations.*;
 import jakarta.validation.*;
 import lombok.*;
 import org.springframework.http.*;
@@ -16,11 +15,9 @@ public class MemberController {
     /**
      * 특정 유저 조회(잔액 조회)
      */
-    @Operation(summary = "특정 유저 조회", description = "특정 회원의 잔액 정보를 조회합니다.")
     @GetMapping("/member")
     public ResponseEntity<MemberResponse> getMember(
-            @Parameter(description = "JWT 인증 토큰", required = true)
-            @RequestHeader(name = "Authorization") String token
+            @RequestHeader String token
     ) {
         return ResponseEntity.ok(
                 new MemberResponse(1L, 50000L)
@@ -30,13 +27,9 @@ public class MemberController {
     /**
      * 특정 유저 충전
      */
-    @Operation(summary = "특정 유저 충전", description = "특정 회원의 잔액을 충전합니다.")
     @PostMapping("/charge")
     public ResponseEntity<MemberResponse> chargeBalance(
-            @Parameter(description = "JWT 인증 토큰", required = true)
-            @RequestHeader(name = "Authorization") String token,
-
-            @Parameter(description = "충전할 금액 정보", required = true)
+            @RequestHeader String token,
             @RequestBody @Valid MemberChargeRequest request
     ) {
         return ResponseEntity.ok(

--- a/src/main/java/com/hanghae/concert/api/payment/IPaymentHistoryController.java
+++ b/src/main/java/com/hanghae/concert/api/payment/IPaymentHistoryController.java
@@ -1,0 +1,21 @@
+package com.hanghae.concert.api.payment;
+
+import com.hanghae.concert.api.payment.dto.request.*;
+import com.hanghae.concert.api.payment.dto.response.*;
+import io.swagger.v3.oas.annotations.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+public interface IPaymentHistoryController {
+
+    /**
+     * 유저의 잔액 사용 히스토리 저장
+     */
+    @Operation(summary = "유저의 잔액 사용 히스토리 저장", description = "회원의 잔액 사용 또는 충전 내역을 저장합니다.")
+    ResponseEntity<List<PaymentHistoryResponse>> createPaymentHistory(
+            @Parameter(description = "충전 또는 사용 금액", required = true)
+            @RequestBody PaymentHistoryCreateRequest request
+    );
+}

--- a/src/main/java/com/hanghae/concert/api/payment/PaymentHistoryController.java
+++ b/src/main/java/com/hanghae/concert/api/payment/PaymentHistoryController.java
@@ -2,8 +2,6 @@ package com.hanghae.concert.api.payment;
 
 import com.hanghae.concert.api.payment.dto.request.*;
 import com.hanghae.concert.api.payment.dto.response.*;
-import io.swagger.v3.oas.annotations.*;
-import lombok.*;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,18 +9,13 @@ import java.util.*;
 
 import static com.hanghae.concert.domain.payment.PaymentType.*;
 
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/payment-history")
 public class PaymentHistoryController {
 
     /**
      * 유저의 잔액 사용 히스토리 저장
      */
-    @Operation(summary = "유저의 잔액 사용 히스토리 저장", description = "회원의 잔액 사용 또는 충전 내역을 저장합니다.")
     @PostMapping
     public ResponseEntity<List<PaymentHistoryResponse>> createPaymentHistory(
-            @Parameter(description = "충전 또는 사용 금액", required = true)
             @RequestBody PaymentHistoryCreateRequest request
     ) {
 

--- a/src/main/java/com/hanghae/concert/api/queue/IMemberQueueController.java
+++ b/src/main/java/com/hanghae/concert/api/queue/IMemberQueueController.java
@@ -1,0 +1,27 @@
+package com.hanghae.concert.api.queue;
+
+import com.hanghae.concert.api.queue.dto.response.*;
+import io.swagger.v3.oas.annotations.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+public interface IMemberQueueController {
+
+    /**
+     * 대기열 생성 API
+     */
+    @Operation(summary = "대기열 생성", description = "회원의 대기열을 생성합니다.")
+    ResponseEntity<MemberQueueCreateResponse> createMemberQueue(
+            @Parameter(description = "대기열을 생성할 회원의 ID", required = true)
+            @PathVariable(name = "memberId") Long memberId
+    );
+
+    /**
+     * 나의 대기 순번 조회 API
+     */
+    @Operation(summary = "나의 대기 순번 조회", description = "나의 대기 순번을 조회합니다.")
+    ResponseEntity<MemberQueueMyTurnResponse> getMyTurn(
+            @Parameter(description = "JWT 인증 토큰", required = true)
+            @RequestHeader(name = "Authorization") String token
+    );
+}

--- a/src/main/java/com/hanghae/concert/api/queue/MemberQueueController.java
+++ b/src/main/java/com/hanghae/concert/api/queue/MemberQueueController.java
@@ -17,11 +17,9 @@ public class MemberQueueController {
     /**
      * 대기열 생성 API
      */
-    @Operation(summary = "대기열 생성", description = "회원의 대기열을 생성합니다.")
     @PostMapping("/{memberId}")
     public ResponseEntity<MemberQueueCreateResponse> createMemberQueue(
-            @Parameter(description = "대기열을 생성할 회원의 ID", required = true)
-            @PathVariable(name = "memberId") Long memberId
+            @PathVariable Long memberId
     ) {
         return ResponseEntity.ok(
                 new MemberQueueCreateResponse(1L, UUID.randomUUID().toString(), LocalDateTime.now().plusMinutes(5))
@@ -31,11 +29,9 @@ public class MemberQueueController {
     /**
      * 나의 대기 순번 조회 API
      */
-    @Operation(summary = "나의 대기 순번 조회", description = "나의 대기 순번을 조회합니다.")
     @GetMapping("/my-turn")
     public ResponseEntity<MemberQueueMyTurnResponse> getMyTurn(
-            @Parameter(description = "JWT 인증 토큰", required = true)
-            @RequestHeader(name = "Authorization") String token
+            @RequestHeader String token
     ) {
         return ResponseEntity.ok(new MemberQueueMyTurnResponse(1L, 1));
     }

--- a/src/main/java/com/hanghae/concert/application/MemberQueueService.java
+++ b/src/main/java/com/hanghae/concert/application/MemberQueueService.java
@@ -1,0 +1,74 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.concert.dto.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.exception.*;
+import com.hanghae.concert.domain.member.queue.*;
+import com.hanghae.concert.domain.member.queue.dto.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+
+import java.time.*;
+import java.util.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MemberQueueService {
+
+    private final MemberQueueQueryService memberQueueQueryService;
+    private final MemberQueueCommandService memberQueueCommandService;
+    private final ConcertQueryService concertQueryService;
+    private final MemberQueryService memberQueryService;
+
+    public MemberQueueDto createToken(Long memberId, Long concertId) {
+
+        // 유저 검증
+        if (!memberQueryService.existsMemberById(memberId)) {
+            throw new MemberNotFoundException();
+        }
+
+        // 콘서트 검증
+        ConcertDto concertDto = ConcertDto.of(concertQueryService.getConcertById(concertId));
+
+        // 발급된 active 토큰이 있다면 그대로 반환
+        return memberQueueQueryService.getMemberQueue(memberId, concertId)
+                .map(MemberQueueDto::of)
+                // 없으면 신규 토큰 발급
+                .orElseGet(() -> {
+
+                    // 대기자 수 확인하여 토큰 발급
+                    TokenStatus tokenStatus = memberQueueQueryService.isActiveTokenOverCapacity(concertId, concertDto.capacity())
+                            ? TokenStatus.WAIT : TokenStatus.ACTIVE;
+
+                    // 토큰 상태에 따른 만료 일시
+                    LocalDateTime expiredAt = tokenStatus == TokenStatus.ACTIVE ? LocalDateTime.now().plusMinutes(5) : null;
+
+                    return MemberQueueDto.of(memberQueueCommandService.save(
+                                    new MemberQueue(
+                                            null,
+                                            memberId,
+                                            concertDto.concertId(),
+                                            UUID.randomUUID().toString(),
+                                            tokenStatus,
+                                            expiredAt
+                                    )
+                            )
+                    );
+                });
+    }
+
+    public Long getMyTurn(String token) {
+
+        MemberQueue memberQueue = memberQueueQueryService.getTokenStatus(token)
+                .orElse(null);
+
+        if (memberQueue.getTokenStatus() != TokenStatus.WAIT) {
+            return null;
+        }
+
+        return memberQueueQueryService.getRankByToken(memberQueue.getId());
+    }
+}

--- a/src/main/java/com/hanghae/concert/application/MemberService.java
+++ b/src/main/java/com/hanghae/concert/application/MemberService.java
@@ -1,0 +1,28 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.exception.*;
+import com.hanghae.concert.domain.payment.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+import java.math.*;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberQueryService memberQueryService;
+    private final MemberCommandService memberCommandService;
+
+    public void updateMemberBalance(Long memberId, Integer balance, PaymentType paymentType) {
+
+        // 유저 검증
+        if (!memberQueryService.existsMemberById(memberId)) {
+            throw new MemberNotFoundException();
+        }
+
+        memberCommandService.updateBalance(memberId, balance, paymentType);
+
+    }
+}

--- a/src/main/java/com/hanghae/concert/application/PaymentService.java
+++ b/src/main/java/com/hanghae/concert/application/PaymentService.java
@@ -1,0 +1,86 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.concert.exception.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.exception.*;
+import com.hanghae.concert.domain.member.queue.*;
+import com.hanghae.concert.domain.member.queue.exception.*;
+import com.hanghae.concert.domain.payment.*;
+import com.hanghae.concert.domain.reservation.*;
+import com.hanghae.concert.domain.reservation.exception.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Service
+public class PaymentService {
+
+    private final MemberCommandService memberCommandService;
+    private final MemberQueryService memberQueryService;
+    private final MemberQueueQueryService memberQueueQueryService;
+    private final MemberQueueCommandService memberQueueCommandService;
+    private final ConcertQueryService concertQueryService;
+    private final ReservationQueryService reservationQueryService;
+    private final ReservationCommandService reservationCommandService;
+    private final PaymentHistoryCommandService paymentHistoryCommandService;
+
+    public void pay(Long memberId, Long concertId, Long reservationId) {
+
+        // 검증
+        validateMemberAndConcert(memberId, concertId);
+
+        // 예약 조회
+        Reservation reservation = reservationQueryService.getReservationById(reservationId);
+
+        // 만료 여부 검증
+        if (reservation.isExpired()) {
+            throw new ExpiredReservationException();
+        }
+
+        // 잔액 차감
+        Integer reservationPrice = reservation.getReservationPrice();
+
+        memberCommandService.updateBalance(memberId, reservationPrice, PaymentType.USE);
+
+        // 결제내역 저장
+        paymentHistoryCommandService.savePaymentHistory(
+                new PaymentHistory(
+                        null,
+                        memberId,
+                        reservationId,
+                        PaymentType.USE,
+                        reservationPrice
+                )
+        );
+
+        // 예약상태 reservation 으로 변경
+        reservation.changeStatus(ReservationStatus.RESERVED);
+        reservationCommandService.save(reservation);
+
+        // 대기열 변경
+        MemberQueue memberQueue = memberQueueQueryService.getMemberQueue(memberId, concertId)
+                .orElseThrow(MemberQueueNotFoundException::new);
+
+        memberQueue.changeStatus(TokenStatus.DONE);
+        memberQueueCommandService.save(memberQueue);
+    }
+
+    private void validateMemberAndConcert(Long memberId, Long concertId) {
+
+        // 유저 검증
+        if (!memberQueryService.existsMemberById(memberId)) {
+            throw new MemberNotFoundException();
+        }
+
+        // 토큰 검증
+        if (!memberQueueQueryService.isAvailableToken(memberId, concertId)) {
+            throw new ActiveTokenNotFoundException();
+        }
+
+        // 콘서트 검증
+        if (!concertQueryService.existsById(concertId)) {
+            throw new ConcertNotFoundException();
+        }
+    }
+}

--- a/src/main/java/com/hanghae/concert/application/ReservationService.java
+++ b/src/main/java/com/hanghae/concert/application/ReservationService.java
@@ -1,0 +1,104 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.concert.exception.*;
+import com.hanghae.concert.domain.concert.schedule.*;
+import com.hanghae.concert.domain.concert.schedule.dto.*;
+import com.hanghae.concert.domain.concert.seat.*;
+import com.hanghae.concert.domain.concert.seat.dto.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.exception.*;
+import com.hanghae.concert.domain.member.queue.*;
+import com.hanghae.concert.domain.member.queue.exception.*;
+import com.hanghae.concert.domain.reservation.*;
+import com.hanghae.concert.domain.reservation.dto.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+
+import java.util.*;
+
+import static com.hanghae.concert.domain.reservation.ReservationStatus.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReservationService {
+
+    private final MemberQueryService memberQueryService;
+    private final MemberQueueQueryService memberQueueQueryService;
+    private final ConcertQueryService concertQueryService;
+    private final ConcertCommandService concertCommandService;
+    private final ConcertScheduleQueryService concertScheduleQueryService;
+    private final ConcertScheduleCommandService concertScheduleCommandService;
+    private final ConcertSeatQueryService concertSeatQueryService;
+    private final ConcertSeatCommandService concertSeatCommandService;
+    private final ReservationCommandService reservationCommandService;
+
+
+    public List<ConcertScheduleDto> searchAvailableDates(Long memberId, Long concertId) {
+
+        validateMemberAndConcert(memberId, concertId);
+
+        return concertScheduleQueryService.getAvailableConcertSchedules(concertId);
+
+    }
+
+    public List<ConcertSeatDto> searchReservedSeats(Long memberId, Long concertId, Long concertScheduleId) {
+
+        validateMemberAndConcert(memberId, concertId);
+
+        return concertSeatQueryService.getReservedSeats(concertScheduleId);
+
+    }
+
+    public ReservationDto tempReservation(Long memberId, Long concertId, Long concertScheduleId, int seatNumber) {
+
+        validateMemberAndConcert(memberId, concertId);
+
+        ConcertSchedule concertSchedule = concertScheduleQueryService.getConcertSchedule(concertScheduleId);
+
+        // seat 생성
+        ConcertSeat concertSeat = concertSeatQueryService.getConcertSeat(concertScheduleId, seatNumber)
+                .orElseGet(() -> concertSeatCommandService.saveConcertSeat(
+                        new SaveConcertSeatDto(concertScheduleId, seatNumber)
+                ));
+
+        // 잔여좌석 업데이트
+        concertSchedule.changeRemainingSeat(true);
+        concertScheduleCommandService.save(concertSchedule);
+
+        Concert concert = concertQueryService.getConcertById(concertSchedule.getConcertId());
+
+        // 정원이 다차면 concert 도 sold_out 상태로 변경
+        if (concertSchedule.getRemainingSeat() == 0) {
+            concert.changeStatus(ConcertStatus.SOLD_OUT);
+            concertCommandService.save(concert);
+        }
+
+        //reservation 테이블 temp_reservation insert
+        Reservation reservation = reservationCommandService.save(
+                new Reservation(null, memberId, concertSeat.getId(), TEMP_RESERVED, concert.getSeatPrice())
+        );
+
+        return ReservationDto.of(reservation);
+    }
+
+    private void validateMemberAndConcert(Long memberId, Long concertId) {
+
+        // 유저 검증
+        if (!memberQueryService.existsMemberById(memberId)) {
+            throw new MemberNotFoundException();
+        }
+
+        // 토큰 검증
+        if (!memberQueueQueryService.isAvailableToken(memberId, concertId)) {
+            throw new ActiveTokenNotFoundException();
+        }
+
+        // 콘서트 검증
+        if (!concertQueryService.existsById(concertId)) {
+            throw new ConcertNotFoundException();
+        }
+    }
+}

--- a/src/main/java/com/hanghae/concert/batch/MemberQueueBatchService.java
+++ b/src/main/java/com/hanghae/concert/batch/MemberQueueBatchService.java
@@ -1,0 +1,60 @@
+package com.hanghae.concert.batch;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.member.queue.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+import java.util.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MemberQueueBatchService {
+
+    private final MemberQueueCommandService memberQueueCommandService;
+    private final MemberQueueQueryService memberQueueQueryService;
+    private final ConcertQueryService concertQueryService;
+
+    public void deleteExpiredToken() {
+
+        memberQueueCommandService.deleteExpiredToken();
+    }
+
+    @Transactional
+    public void changeTokenStatusWaitToActive(LocalDateTime expiredAt) {
+
+        List<Long> concertIdsIncludeWait = memberQueueQueryService.getConcertIds(TokenStatus.WAIT);
+
+        // 콘서트 별
+        for (Long concertId : concertIdsIncludeWait) {
+            int room = getCapacityRoom(concertId);
+
+            if (room > 0) {
+                Pageable pageable = PageRequest.of(0, room);
+                List<MemberQueue> targets = memberQueueQueryService.getTokenStatusChangeTarget(
+                        concertId, TokenStatus.WAIT, pageable
+                );
+
+                for (MemberQueue target : targets) {
+                    target.changeStatus(TokenStatus.ACTIVE);
+                    target.changeExpiredAt(expiredAt);
+                    memberQueueCommandService.save(target);
+                }
+            }
+        }
+    }
+
+    private int getCapacityRoom(Long concertId) {
+
+        Integer capacity = concertQueryService.getConcertById(concertId).getCapacity();
+
+        int activeTokenCount = memberQueueQueryService.getActiveTokenCount(concertId);
+
+        return capacity - activeTokenCount;
+    }
+}

--- a/src/main/java/com/hanghae/concert/batch/task/MemberQueueTask.java
+++ b/src/main/java/com/hanghae/concert/batch/task/MemberQueueTask.java
@@ -1,0 +1,31 @@
+package com.hanghae.concert.batch.task;
+
+import com.hanghae.concert.batch.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.scheduling.annotation.*;
+import org.springframework.stereotype.*;
+
+import java.time.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberQueueTask {
+
+    private final MemberQueueBatchService memberQueueBatchService;
+
+    @Scheduled(cron = "0 * * * * *")
+    public void deleteExpiredToken() {
+
+        memberQueueBatchService.deleteExpiredToken();
+    }
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void changeTokenStatusWaitToActive() {
+
+        LocalDateTime fiveMinutesLater = LocalDateTime.now().plusMinutes(5);
+
+        memberQueueBatchService.changeTokenStatusWaitToActive(fiveMinutesLater);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/Concert.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/Concert.java
@@ -25,6 +25,11 @@ public class Concert extends BaseEntity {
     @Column(name = "seatPrice", nullable = false)
     private Integer seatPrice;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private ConcertStatus concertStatus;
+
+    public void changeStatus(ConcertStatus concertStatus) {
+        this.concertStatus = concertStatus;
+    }
 }

--- a/src/main/java/com/hanghae/concert/domain/concert/ConcertCommandService.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/ConcertCommandService.java
@@ -1,0 +1,20 @@
+package com.hanghae.concert.domain.concert;
+
+import com.hanghae.concert.domain.concert.dto.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ConcertCommandService {
+
+    private final ConcertRepository concertRepository;
+
+
+    public Concert save(Concert concert) {
+
+        return concertRepository.save(concert);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/ConcertQueryService.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/ConcertQueryService.java
@@ -1,0 +1,28 @@
+package com.hanghae.concert.domain.concert;
+
+import com.hanghae.concert.domain.concert.dto.*;
+import com.hanghae.concert.domain.concert.exception.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ConcertQueryService {
+
+    private final ConcertRepository concertRepository;
+
+
+    public Concert getConcertById(Long concertId) {
+
+        return concertRepository.findById(concertId)
+                .orElseThrow(ConcertNotFoundException::new);
+    }
+
+
+    public Boolean existsById(Long concertId) {
+
+        return concertRepository.existsById(concertId);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/ConcertRepository.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/ConcertRepository.java
@@ -1,0 +1,8 @@
+package com.hanghae.concert.domain.concert;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface ConcertRepository extends JpaRepository<Concert, Long> {
+
+    boolean existsById(Long concertId);
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/dto/ConcertDto.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/dto/ConcertDto.java
@@ -1,0 +1,24 @@
+package com.hanghae.concert.domain.concert.dto;
+
+import com.hanghae.concert.domain.concert.*;
+
+public record ConcertDto(
+        Long concertId,
+        String title,
+        Integer capacity,
+        Integer seatPrice,
+        ConcertStatus concertStatus
+) {
+    public static ConcertDto of(Concert concert) {
+
+        if (concert == null) return null;
+
+        return new ConcertDto(
+                concert.getId(),
+                concert.getTitle(),
+                concert.getCapacity(),
+                concert.getSeatPrice(),
+                concert.getConcertStatus()
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/dto/SaveConcertDto.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/dto/SaveConcertDto.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.concert.dto;
+
+import com.hanghae.concert.domain.concert.*;
+
+public record SaveConcertDto(
+        String title,
+        Integer capacity,
+        Integer seatPrice,
+        ConcertStatus concertStatus
+) {
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/exception/ConcertNotFoundException.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/exception/ConcertNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.concert.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+
+public class ConcertNotFoundException extends NotFoundException {
+
+    public ConcertNotFoundException() {
+        super("콘서트 정보가 존재하지 않습니다");
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertSchedule.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertSchedule.java
@@ -26,4 +26,12 @@ public class ConcertSchedule extends BaseEntity {
 
     @Column(name = "start_at", nullable = false)
     private LocalDateTime startAt;
+
+    public void changeRemainingSeat(boolean isReserved) {
+        if (isReserved) {
+            this.remainingSeat -= 1;
+        } else {
+            this.remainingSeat += 1;
+        }
+    }
 }

--- a/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleCommandService.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleCommandService.java
@@ -1,0 +1,19 @@
+package com.hanghae.concert.domain.concert.schedule;
+
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ConcertScheduleCommandService {
+
+    private final ConcertScheduleRepository concertScheduleRepository;
+
+
+    public ConcertSchedule save(ConcertSchedule concertSchedule) {
+
+        return concertScheduleRepository.save(concertSchedule);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleQueryService.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleQueryService.java
@@ -1,0 +1,35 @@
+package com.hanghae.concert.domain.concert.schedule;
+
+import com.hanghae.concert.domain.concert.schedule.dto.*;
+import com.hanghae.concert.domain.concert.schedule.exception.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ConcertScheduleQueryService {
+
+    private final ConcertScheduleRepository concertScheduleRepository;
+
+
+    public List<ConcertScheduleDto> getAvailableConcertSchedules(Long concertId) {
+
+        List<ConcertSchedule> concertSchedules = concertScheduleRepository.findAllByConcertId(concertId);
+
+        return concertSchedules.stream()
+                .filter(it -> it.getRemainingSeat() > 0)
+                .map(ConcertScheduleDto::of)
+                .collect(Collectors.toList());
+    }
+
+    public ConcertSchedule getConcertSchedule(Long concertScheduleId) {
+
+        return concertScheduleRepository.findById(concertScheduleId)
+                .orElseThrow(ConcertScheduleNotFoundException::new);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleRepository.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleRepository.java
@@ -1,0 +1,10 @@
+package com.hanghae.concert.domain.concert.schedule;
+
+import org.springframework.data.jpa.repository.*;
+
+import java.util.*;
+
+public interface ConcertScheduleRepository extends JpaRepository<ConcertSchedule, Long> {
+
+  List<ConcertSchedule> findAllByConcertId(Long concertId);
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/schedule/dto/ConcertScheduleDto.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/schedule/dto/ConcertScheduleDto.java
@@ -1,0 +1,25 @@
+package com.hanghae.concert.domain.concert.schedule.dto;
+
+import com.hanghae.concert.domain.concert.schedule.*;
+
+import java.time.*;
+
+public record ConcertScheduleDto(
+        Long id,
+        Long concertId,
+        Integer remainingSeat,
+        LocalDateTime startAt
+) {
+
+    public static ConcertScheduleDto of(ConcertSchedule concertSchedule) {
+
+        if (concertSchedule == null) return null;
+
+        return new ConcertScheduleDto(
+                concertSchedule.getId(),
+                concertSchedule.getConcertId(),
+                concertSchedule.getRemainingSeat(),
+                concertSchedule.getStartAt()
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/schedule/exception/ConcertScheduleNotFoundException.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/schedule/exception/ConcertScheduleNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.concert.schedule.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+
+public class ConcertScheduleNotFoundException extends NotFoundException {
+
+    public ConcertScheduleNotFoundException() {
+        super("콘서트 상세 정보가 존재하지 않습니다");
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeat.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeat.java
@@ -22,6 +22,6 @@ public class ConcertSeat extends BaseEntity {
     @Column(name = "seat_number", nullable = false)
     private Integer seatNumber;
 
-    @Column(name = "is_availabe", nullable = false)
-    private Boolean isAvailable;
+    @Column(name = "is_reserved", nullable = false)
+    private Boolean isReserved;
 }

--- a/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeatCommandService.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeatCommandService.java
@@ -1,0 +1,27 @@
+package com.hanghae.concert.domain.concert.seat;
+
+import com.hanghae.concert.domain.concert.seat.dto.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ConcertSeatCommandService {
+
+    private final ConcertSeatRepository concertSeatRepository;
+
+
+    public ConcertSeat saveConcertSeat(SaveConcertSeatDto dto) {
+
+        return concertSeatRepository.save(
+                new ConcertSeat(
+                        null,
+                        dto.concertScheduleId(),
+                        dto.seatNumber(),
+                        true
+                )
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeatQueryService.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeatQueryService.java
@@ -1,0 +1,46 @@
+package com.hanghae.concert.domain.concert.seat;
+
+import com.hanghae.concert.domain.concert.schedule.*;
+import com.hanghae.concert.domain.concert.schedule.dto.*;
+import com.hanghae.concert.domain.concert.seat.dto.*;
+import com.hanghae.concert.domain.concert.seat.exception.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ConcertSeatQueryService {
+
+    private final ConcertSeatRepository concertSeatRepository;
+
+    /**
+     * review point<br>
+     * 콘서트 정보 생성 시, 좌석까지 일괄 생성하게 되면 데이터 비효율이 발생할 것으로 생각<br>
+     * 그래서 예약된 좌석을 올려서, 프론트에서 가능한 좌석만 보여 주는 것으로 설계
+     */
+    public List<ConcertSeatDto> getReservedSeats(Long concertScheduleId) {
+
+        List<ConcertSeat> concertSeats = concertSeatRepository.findAllByConcertScheduleId(concertScheduleId);
+
+        return concertSeats.stream()
+                .filter(ConcertSeat::getIsReserved)
+                .map(ConcertSeatDto::of)
+                .collect(Collectors.toList());
+    }
+
+    public Optional<ConcertSeat> getConcertSeat(Long concertScheduleId, int seatNumber) {
+
+        return concertSeatRepository.findByConcertScheduleIdAndSeatNumber(concertScheduleId, seatNumber);
+    }
+
+    public ConcertSeat getConcertSeatById(Long concertSeatId) {
+
+        return concertSeatRepository.findById(concertSeatId)
+                .orElseThrow(ConcertSeatNotFoundException::new);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeatRepository.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/seat/ConcertSeatRepository.java
@@ -1,0 +1,12 @@
+package com.hanghae.concert.domain.concert.seat;
+
+import org.springframework.data.jpa.repository.*;
+
+import java.util.*;
+
+public interface ConcertSeatRepository extends JpaRepository<ConcertSeat, Long> {
+
+    List<ConcertSeat> findAllByConcertScheduleId(Long concertScheduleId);
+
+    Optional<ConcertSeat> findByConcertScheduleIdAndSeatNumber(Long concertScheduleId, int seatNumber);
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/seat/dto/ConcertSeatDto.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/seat/dto/ConcertSeatDto.java
@@ -1,0 +1,23 @@
+package com.hanghae.concert.domain.concert.seat.dto;
+
+import com.hanghae.concert.domain.concert.seat.*;
+
+public record ConcertSeatDto(
+        Long id,
+        Long concertScheduleId,
+        Integer seatNumber,
+        Boolean isReserved
+) {
+
+    public static ConcertSeatDto of(ConcertSeat concertSeat) {
+
+        if (concertSeat == null) return null;
+
+        return new ConcertSeatDto(
+                concertSeat.getId(),
+                concertSeat.getConcertScheduleId(),
+                concertSeat.getSeatNumber(),
+                concertSeat.getIsReserved()
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/seat/dto/SaveConcertSeatDto.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/seat/dto/SaveConcertSeatDto.java
@@ -1,0 +1,7 @@
+package com.hanghae.concert.domain.concert.seat.dto;
+
+public record SaveConcertSeatDto(
+        Long concertScheduleId,
+        Integer seatNumber
+) {
+}

--- a/src/main/java/com/hanghae/concert/domain/concert/seat/exception/ConcertSeatNotFoundException.java
+++ b/src/main/java/com/hanghae/concert/domain/concert/seat/exception/ConcertSeatNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.concert.seat.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+
+public class ConcertSeatNotFoundException extends NotFoundException {
+
+    public ConcertSeatNotFoundException() {
+        super("좌석 정보가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/Member.java
+++ b/src/main/java/com/hanghae/concert/domain/member/Member.java
@@ -1,6 +1,7 @@
 package com.hanghae.concert.domain.member;
 
 import com.hanghae.concert.domain.*;
+import com.hanghae.concert.domain.payment.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,5 +18,36 @@ public class Member extends BaseEntity {
     private Long id;
 
     @Column(name = "balance", nullable = false)
-    private Long balance = 0L;
+    private Integer balance = 0;
+
+
+    public void changeBalance(Integer changeBalance, PaymentType paymentType) {
+
+        if (paymentType == PaymentType.CHARGE) {
+            validateCharge(changeBalance);
+            this.balance += changeBalance;
+        } else if (paymentType == PaymentType.USE) {
+            validateUse(changeBalance);
+            this.balance -= changeBalance;
+        }
+
+    }
+
+    private void validateCharge(Integer balance) {
+
+        if (balance <= 0) {
+            throw new IllegalArgumentException("마이너스 금액 또는 0원을 충전할 수 없습니다.");
+        }
+    }
+
+    private void validateUse(Integer balance) {
+
+        if (balance <= 0) {
+            throw new IllegalArgumentException("마이너스 금액 또는 0원을 사용할 수 없습니다.");
+        }
+
+        if (this.balance < balance) {
+            throw new IllegalArgumentException("차감할 포인트가 부족합니다.");
+        }
+    }
 }

--- a/src/main/java/com/hanghae/concert/domain/member/MemberCommandService.java
+++ b/src/main/java/com/hanghae/concert/domain/member/MemberCommandService.java
@@ -1,0 +1,31 @@
+package com.hanghae.concert.domain.member;
+
+import com.hanghae.concert.domain.member.dto.*;
+import com.hanghae.concert.domain.member.exception.*;
+import com.hanghae.concert.domain.payment.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberCommandService {
+
+    private final MemberRepository memberRepository;
+
+    public Member initMember(Member member) {
+
+       return memberRepository.save(member);
+    }
+
+    public void updateBalance(Long memberId, Integer balance, PaymentType paymentType) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        member.changeBalance(balance, paymentType);
+
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/MemberQueryService.java
+++ b/src/main/java/com/hanghae/concert/domain/member/MemberQueryService.java
@@ -1,0 +1,25 @@
+package com.hanghae.concert.domain.member;
+
+import com.hanghae.concert.domain.member.exception.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMemberById(Long memberId) {
+
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    public Boolean existsMemberById(Long memberId) {
+
+        return memberRepository.existsById(memberId);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/MemberRepository.java
+++ b/src/main/java/com/hanghae/concert/domain/member/MemberRepository.java
@@ -1,0 +1,6 @@
+package com.hanghae.concert.domain.member;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/hanghae/concert/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/hanghae/concert/domain/member/dto/MemberDto.java
@@ -1,0 +1,18 @@
+package com.hanghae.concert.domain.member.dto;
+
+import com.hanghae.concert.domain.member.*;
+
+public record MemberDto(
+        Long id,
+        Integer balance
+) {
+    public static MemberDto of(Member member) {
+
+        if (member == null) return null;
+
+        return new MemberDto(
+                member.getId(),
+                member.getBalance()
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/hanghae/concert/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.member.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+
+public class MemberNotFoundException extends NotFoundException {
+
+    public MemberNotFoundException() {
+        super("고객 정보가 존재하지 않습니다");
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueue.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueue.java
@@ -21,12 +21,24 @@ public class MemberQueue extends BaseEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
+    @Column(name = "concert_id", nullable = false)
+    private Long concertId;
+
     @Column(name = "token", length = 255, nullable = false)
     private String token;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 10, nullable = false)
     private TokenStatus tokenStatus;
 
-    @Column(name = "expired_at", nullable = false)
+    @Column(name = "expired_at")
     private LocalDateTime expiredAt;
+
+    public void changeStatus(TokenStatus tokenStatus) {
+        this.tokenStatus = tokenStatus;
+    }
+
+    public void changeExpiredAt(LocalDateTime expiredAt) {
+        this.expiredAt = expiredAt;
+    }
 }

--- a/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueueCommandService.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueueCommandService.java
@@ -1,0 +1,25 @@
+package com.hanghae.concert.domain.member.queue;
+
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberQueueCommandService {
+
+    private final MemberQueueRepository memberQueueRepository;
+
+    public MemberQueue save(MemberQueue memberQueue) {
+
+        return memberQueueRepository.save(memberQueue);
+    }
+
+    public void deleteExpiredToken() {
+
+        memberQueueRepository.deleteByTokenStatusAndExpiredAtBefore(TokenStatus.ACTIVE, LocalDateTime.now().minusMinutes(5));
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueueQueryService.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueueQueryService.java
@@ -1,0 +1,59 @@
+package com.hanghae.concert.domain.member.queue;
+
+import lombok.*;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class MemberQueueQueryService {
+
+    private final MemberQueueRepository memberQueueRepository;
+
+
+    public Integer getActiveTokenCount(Long concertId) {
+
+       return memberQueueRepository.countByConcertIdAndTokenStatus(concertId, TokenStatus.ACTIVE);
+    }
+
+    public boolean isActiveTokenOverCapacity(Long concertId, int capacity) {
+
+        long activeTokenCount = this.getActiveTokenCount(concertId);
+
+        return activeTokenCount >= capacity;
+    }
+
+    public Optional<MemberQueue> getMemberQueue(Long memberId, Long concertId) {
+
+        return memberQueueRepository.findByMemberIdAndConcertIdAndTokenStatus(memberId, concertId, TokenStatus.ACTIVE); //Todo wati
+    }
+
+    public boolean isAvailableToken(Long memberId, Long concertId) {
+
+        return memberQueueRepository.existsByMemberIdAndConcertIdAndTokenStatus(memberId, concertId, TokenStatus.ACTIVE);
+    }
+
+    public Optional<MemberQueue> getTokenStatus(String token) {
+
+        return memberQueueRepository.findTokenStatusByToken(token);
+    }
+
+    public Long getRankByToken(Long memberQueueId) {
+
+        return memberQueueRepository.countByTokenStatusAndIdLessThanEqual(TokenStatus.WAIT, memberQueueId);
+    }
+
+    public List<Long> getConcertIds(TokenStatus tokenStatus) {
+
+        return memberQueueRepository.findAllConcertIds(tokenStatus);
+    }
+
+    public List<MemberQueue> getTokenStatusChangeTarget(Long concertId, TokenStatus status, Pageable room) {
+
+        return memberQueueRepository.findChangeExpiredToActive(concertId, status, room);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueueRepository.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/MemberQueueRepository.java
@@ -1,0 +1,33 @@
+package com.hanghae.concert.domain.member.queue;
+
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.*;
+
+import java.time.*;
+import java.util.*;
+
+public interface MemberQueueRepository extends JpaRepository<MemberQueue, Long> {
+
+    int countByConcertIdAndTokenStatus(Long concertId, TokenStatus tokenStatus);
+
+    Optional<MemberQueue> findByMemberIdAndConcertIdAndTokenStatus(Long memberId, Long concertId, TokenStatus tokenStatus);
+
+    boolean existsByMemberIdAndConcertIdAndTokenStatus(Long memberId, Long concertId, TokenStatus tokenStatus);
+
+    Optional<MemberQueue> findTokenStatusByToken(String token);
+
+    long countByTokenStatusAndIdLessThanEqual(TokenStatus tokenStatus, Long memberQueueId);
+
+    void deleteByTokenStatusAndExpiredAtBefore(TokenStatus tokenStatus, LocalDateTime expiredAt);
+
+    @Query("SELECT DISTINCT mq.concertId FROM MemberQueue mq WHERE mq.tokenStatus = :tokenStatus ")
+    List<Long> findAllConcertIds(@Param("tokenStatus") TokenStatus tokenStatus);
+
+    @Query("SELECT mq FROM MemberQueue mq " + "WHERE mq.tokenStatus = :tokenStatus " + "AND mq.concertId = :concertId " + "ORDER BY mq.createdAt ASC")
+    List<MemberQueue> findChangeExpiredToActive(@Param("concertId") Long concertId, @Param("tokenStatus") TokenStatus tokenStatus, Pageable pageable);
+
+    List<MemberQueue> findByConcertIdAndTokenStatus(Long concertId, TokenStatus tokenStatus);
+
+    Optional<MemberQueue> findByMemberIdAndConcertId(Long memberId, Long concertId);
+}

--- a/src/main/java/com/hanghae/concert/domain/member/queue/TokenStatus.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/TokenStatus.java
@@ -2,7 +2,8 @@ package com.hanghae.concert.domain.member.queue;
 
 public enum TokenStatus {
 
-    WAIT,
-    PROGRESS,
-    EXPIRED
+    WAIT, //대기자
+    ACTIVE, // 입장가능
+    DONE, // 결제완료자 --> 남길 생각.
+    EXPIRED, // 만료자 --> 배치가  돌면서 삭제할 예정
 }

--- a/src/main/java/com/hanghae/concert/domain/member/queue/dto/MemberQueueDto.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/dto/MemberQueueDto.java
@@ -1,0 +1,22 @@
+package com.hanghae.concert.domain.member.queue.dto;
+
+import com.hanghae.concert.domain.member.queue.*;
+
+import java.time.*;
+
+public record MemberQueueDto(
+        Long memberId,
+        String token,
+        TokenStatus tokenStatus,
+        LocalDateTime expiredAt
+) {
+    public static MemberQueueDto of(MemberQueue memberQueue) {
+
+        return new MemberQueueDto(
+                memberQueue.getMemberId(),
+                memberQueue.getToken(),
+                memberQueue.getTokenStatus(),
+                memberQueue.getExpiredAt()
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/queue/dto/SaveMemberQueueDto.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/dto/SaveMemberQueueDto.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.member.queue.dto;
+
+import com.hanghae.concert.domain.member.queue.*;
+
+import java.time.*;
+
+public record SaveMemberQueueDto(
+        Long memberId,
+        String token
+) {
+}

--- a/src/main/java/com/hanghae/concert/domain/member/queue/exception/ActiveTokenNotFoundException.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/exception/ActiveTokenNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.member.queue.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+
+public class ActiveTokenNotFoundException extends BusinessException {
+
+    public ActiveTokenNotFoundException() {
+        super("입장 가능한 토큰이 존재하지 않습니다");
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/member/queue/exception/MemberQueueNotFoundException.java
+++ b/src/main/java/com/hanghae/concert/domain/member/queue/exception/MemberQueueNotFoundException.java
@@ -1,0 +1,12 @@
+package com.hanghae.concert.domain.member.queue.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+import org.aspectj.weaver.ast.*;
+
+public class MemberQueueNotFoundException extends NotFoundException {
+
+    public MemberQueueNotFoundException() {
+        super("토큰이 존재하지 않습니다");
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/payment/PaymentHistory.java
+++ b/src/main/java/com/hanghae/concert/domain/payment/PaymentHistory.java
@@ -22,9 +22,10 @@ public class PaymentHistory extends BaseCreateEntity {
     @Column(name = "reservation_id", nullable = false)
     private Long reservationId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private PaymentType paymentType;
 
     @Column(name = "amount", nullable = false)
-    private Long amount;
+    private Integer amount;
 }

--- a/src/main/java/com/hanghae/concert/domain/payment/PaymentHistoryCommandService.java
+++ b/src/main/java/com/hanghae/concert/domain/payment/PaymentHistoryCommandService.java
@@ -1,0 +1,25 @@
+package com.hanghae.concert.domain.payment;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.concert.dto.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.dto.*;
+import com.hanghae.concert.domain.member.exception.*;
+import com.hanghae.concert.domain.payment.dto.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PaymentHistoryCommandService {
+
+    private final PaymentHistoryRepository paymentHistoryRepository;
+
+
+    public PaymentHistory savePaymentHistory(PaymentHistory paymentHistory) {
+
+        return paymentHistoryRepository.save(paymentHistory);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/payment/PaymentHistoryQueryService.java
+++ b/src/main/java/com/hanghae/concert/domain/payment/PaymentHistoryQueryService.java
@@ -1,0 +1,31 @@
+package com.hanghae.concert.domain.payment;
+
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.dto.*;
+import com.hanghae.concert.domain.member.exception.*;
+import com.hanghae.concert.domain.payment.dto.*;
+import com.hanghae.concert.domain.payment.exception.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class PaymentHistoryQueryService {
+
+    private final PaymentHistoryRepository paymentHistoryRepository;
+
+    public PaymentHistoryDto getPaymentHistoryById(Long paymentHistoryId) {
+
+        PaymentHistory paymentHistory = paymentHistoryRepository.findById(paymentHistoryId)
+                .orElseThrow(PaymentHistoryNotFoundException::new);
+
+        return PaymentHistoryDto.of(paymentHistory);
+    }
+
+    public Boolean existsPaymentHistoryById(Long paymentHistoryId) {
+
+        return paymentHistoryRepository.existsById(paymentHistoryId);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/payment/PaymentHistoryRepository.java
+++ b/src/main/java/com/hanghae/concert/domain/payment/PaymentHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.hanghae.concert.domain.payment;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
+}

--- a/src/main/java/com/hanghae/concert/domain/payment/dto/PaymentHistoryDto.java
+++ b/src/main/java/com/hanghae/concert/domain/payment/dto/PaymentHistoryDto.java
@@ -1,0 +1,21 @@
+package com.hanghae.concert.domain.payment.dto;
+
+import com.hanghae.concert.domain.payment.*;
+
+public record PaymentHistoryDto(
+        Long id,
+        Long memberId,
+        Long reservationId,
+        PaymentType paymentType
+) {
+
+    public static PaymentHistoryDto of(PaymentHistory paymentHistory) {
+
+        return new PaymentHistoryDto(
+                paymentHistory.getMemberId(),
+                paymentHistory.getMemberId(),
+                paymentHistory.getReservationId(),
+                paymentHistory.getPaymentType()
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/payment/dto/SavePaymentHistoryDto.java
+++ b/src/main/java/com/hanghae/concert/domain/payment/dto/SavePaymentHistoryDto.java
@@ -1,0 +1,12 @@
+package com.hanghae.concert.domain.payment.dto;
+
+import com.hanghae.concert.domain.payment.*;
+
+public record SavePaymentHistoryDto(
+        Long id,
+        Long memberId,
+        Long reservationId,
+        PaymentType paymentType,
+        Long amount
+) {
+}

--- a/src/main/java/com/hanghae/concert/domain/payment/exception/PaymentHistoryNotFoundException.java
+++ b/src/main/java/com/hanghae/concert/domain/payment/exception/PaymentHistoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.payment.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+
+public class PaymentHistoryNotFoundException extends NotFoundException {
+
+    public PaymentHistoryNotFoundException() {
+        super("결제 히스토리 정보가 존재하지 않습니다");
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/reservation/Reservation.java
+++ b/src/main/java/com/hanghae/concert/domain/reservation/Reservation.java
@@ -19,15 +19,21 @@ public class Reservation extends BaseEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    @Column(name = "concert_schedule_id", nullable = false)
-    private Long concertScheduleId;
-
     @Column(name = "concert_seat_id", nullable = false)
     private Long concertSeatId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private ReservationStatus reservationStatus;
 
-    @Column(name = "price", nullable = false)
-    private Long price;
+    @Column(name = "reservation_price", nullable = false)
+    private Integer reservationPrice;
+
+    public boolean isExpired() {
+        return reservationStatus == ReservationStatus.EXPIRED;
+    }
+
+    public void changeStatus(ReservationStatus reservationStatus) {
+        this.reservationStatus = reservationStatus;
+    }
 }

--- a/src/main/java/com/hanghae/concert/domain/reservation/ReservationCommandService.java
+++ b/src/main/java/com/hanghae/concert/domain/reservation/ReservationCommandService.java
@@ -1,0 +1,19 @@
+package com.hanghae.concert.domain.reservation;
+
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReservationCommandService {
+
+    private final ReservationRepository reservationRepository;
+
+
+    public Reservation save(Reservation reservation) {
+
+       return reservationRepository.save(reservation);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/reservation/ReservationQueryService.java
+++ b/src/main/java/com/hanghae/concert/domain/reservation/ReservationQueryService.java
@@ -1,0 +1,20 @@
+package com.hanghae.concert.domain.reservation;
+
+import com.hanghae.concert.domain.payment.exception.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ReservationQueryService {
+
+    private final ReservationRepository reservationRepository;
+
+    public Reservation getReservationById(Long reservationId) {
+
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(PaymentHistoryNotFoundException::new);
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/hanghae/concert/domain/reservation/ReservationRepository.java
@@ -1,0 +1,6 @@
+package com.hanghae.concert.domain.reservation;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/com/hanghae/concert/domain/reservation/dto/ReservationDto.java
+++ b/src/main/java/com/hanghae/concert/domain/reservation/dto/ReservationDto.java
@@ -1,0 +1,25 @@
+package com.hanghae.concert.domain.reservation.dto;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.reservation.*;
+
+public record ReservationDto(
+        Long reservationId,
+        Long memberId,
+        Long concertSeatId,
+        ReservationStatus reservationStatus,
+        Integer reservationPrice
+) {
+    public static ReservationDto of(Reservation reservation) {
+
+        if (reservation == null) return null;
+
+        return new ReservationDto(
+                reservation.getId(),
+                reservation.getMemberId(),
+                reservation.getConcertSeatId(),
+                reservation.getReservationStatus(),
+                reservation.getReservationPrice()
+        );
+    }
+}

--- a/src/main/java/com/hanghae/concert/domain/reservation/dto/SaveReservationDto.java
+++ b/src/main/java/com/hanghae/concert/domain/reservation/dto/SaveReservationDto.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.reservation.dto;
+
+import com.hanghae.concert.domain.reservation.*;
+
+public record SaveReservationDto(
+        Long memberId,
+        Long concertSeatId,
+        ReservationStatus reservationStatus,
+        Integer reservationPrice
+) {
+}

--- a/src/main/java/com/hanghae/concert/domain/reservation/exception/ExpiredReservationException.java
+++ b/src/main/java/com/hanghae/concert/domain/reservation/exception/ExpiredReservationException.java
@@ -1,0 +1,11 @@
+package com.hanghae.concert.domain.reservation.exception;
+
+
+import com.hanghae.concert.api.common.exception.*;
+
+public class ExpiredReservationException extends BusinessException {
+
+    public ExpiredReservationException() {
+        super("만료된 예약 입니다.");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   #  driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/com/hanghae/concert/ConcertReservationApplicationTests.java
+++ b/src/test/java/com/hanghae/concert/ConcertReservationApplicationTests.java
@@ -1,4 +1,4 @@
-package com.hanghae.concert_reservation;
+package com.hanghae.concert;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/hanghae/concert/application/MemberQueueMyTurnServiceTest.java
+++ b/src/test/java/com/hanghae/concert/application/MemberQueueMyTurnServiceTest.java
@@ -1,0 +1,48 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.member.queue.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class MemberQueueMyTurnServiceTest {
+
+    @Autowired
+    private MemberQueueService memberQueueService;
+
+    @Autowired
+    private MemberQueueCommandService memberQueueCommandService;
+
+    @BeforeEach
+    void setUp() {
+
+        MemberQueue memberQueue = new MemberQueue(1L, 1L, 1L, "asdf1", TokenStatus.WAIT, null);
+        MemberQueue memberQueue1 = new MemberQueue(2L, 2L, 1L, "asdf2", TokenStatus.WAIT, null);
+        MemberQueue memberQueue2 = new MemberQueue(3L, 2L, 1L, "asdf2", TokenStatus.ACTIVE, null);
+        MemberQueue memberQueue3 = new MemberQueue(4L, 2L, 1L, "asdf2", TokenStatus.ACTIVE, null);
+        MemberQueue memberQueue4 = new MemberQueue(5L, 3L, 1L, "asdf3", TokenStatus.WAIT, null);
+
+        memberQueueCommandService.save(memberQueue);
+        memberQueueCommandService.save(memberQueue1);
+        memberQueueCommandService.save(memberQueue2);
+        memberQueueCommandService.save(memberQueue3);
+        memberQueueCommandService.save(memberQueue4);
+    }
+
+    @Test
+    @DisplayName("대기자 중에서 나의 순번 조회")
+    void getMyTurn() {
+
+        //given
+        String token = "asdf3";
+
+        //when
+        Long myTurn = memberQueueService.getMyTurn(token);
+
+        //then
+        assertThat(myTurn).isEqualTo(3L);
+    }
+}

--- a/src/test/java/com/hanghae/concert/application/MemberUpdateBalanceServiceTest.java
+++ b/src/test/java/com/hanghae/concert/application/MemberUpdateBalanceServiceTest.java
@@ -1,0 +1,76 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.payment.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.test.annotation.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class MemberUpdateBalanceServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberCommandService memberCommandService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        Member member = new Member(1L, 100);  // 처음에 잔액이 0인 회원을 생성
+        memberCommandService.initMember(member);
+
+        memberId = member.getId();
+    }
+
+    @AfterEach
+    void clear() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DirtiesContext //스프링 컨텍스트 새로고침
+    @DisplayName("고객의 잔액을 충전한다.")
+    void chargeBalance() {
+
+        // given
+        int chargeAmount = 100;
+        int result = 200;
+        PaymentType paymentType = PaymentType.CHARGE;
+
+        // when
+        memberService.updateMemberBalance(memberId, chargeAmount, paymentType);
+
+        // then
+        Member updatedMember = memberRepository.findById(memberId).orElse(null);
+
+        assertThat(updatedMember.getBalance()).isEqualTo(result);
+    }
+
+    @Test
+    @DirtiesContext //스프링 컨텍스트 새로고침
+    @DisplayName("고객의 잔액을 사용한다.")
+    void useBalance() {
+
+        // given
+        int useAmount = 100;
+        int result = 0;
+        PaymentType paymentType = PaymentType.USE;
+
+        // when
+        memberService.updateMemberBalance(memberId, useAmount, paymentType);
+
+        // then
+        Member updatedMember = memberRepository.findById(memberId).orElse(null);
+
+        assertThat(updatedMember.getBalance()).isEqualTo(result);
+    }
+}

--- a/src/test/java/com/hanghae/concert/application/PaymentServiceTest.java
+++ b/src/test/java/com/hanghae/concert/application/PaymentServiceTest.java
@@ -1,0 +1,125 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.queue.*;
+import com.hanghae.concert.domain.payment.*;
+import com.hanghae.concert.domain.reservation.*;
+import com.hanghae.concert.domain.reservation.exception.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.test.annotation.*;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class PaymentServiceTest {
+
+    @Autowired
+    private PaymentService paymentService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ConcertRepository concertRepository;
+    @Autowired
+    private ReservationCommandService reservationCommandService;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private MemberQueueRepository memberQueueRepository;
+    @Autowired
+    private PaymentHistoryRepository paymentHistoryRepository;
+
+    Long memberId;
+    Long concertId;
+    Long reservationId;
+
+    @BeforeEach
+    void setUp() {
+
+        Member member = new Member(1L, 50000);
+        memberRepository.save(member);
+
+        Concert concert = new Concert(1L, "제목", 50, 10000, ConcertStatus.AVAILABLE);
+        concertRepository.save(concert);
+
+        MemberQueue memberQueue = new MemberQueue(1L, member.getId(), concert.getId(), "asdf", TokenStatus.ACTIVE, LocalDateTime.now().plusMinutes(5));
+        memberQueueRepository.save(memberQueue);
+
+        Reservation reservation = new Reservation(1L, member.getId(), 1L, ReservationStatus.TEMP_RESERVED, 10000);  // 예약 금액 10000
+        reservationRepository.save(reservation);
+
+        memberId = member.getId();
+        concertId = concert.getId();
+        reservationId = reservation.getId();
+    }
+
+    @AfterEach
+    void clear() {
+        memberRepository.deleteAll();
+        concertRepository.deleteAll();
+        memberQueueRepository.deleteAll();
+        reservationRepository.deleteAll();
+        paymentHistoryRepository.deleteAll();
+    }
+
+    @Test
+    @DirtiesContext
+    @DisplayName("결제가 완료 후 status Done 으로 변경 된다.")
+    void paySuccessTest() {
+
+        // given
+
+        // when
+        paymentService.pay(memberId, concertId, reservationId);
+
+        // then
+        // 잔액 차감 확인
+        Member updatedMember = memberRepository.findById(memberId).orElseThrow();
+        assertThat(updatedMember.getBalance()).isEqualTo(40000);  // 50000 - 10000 = 40000
+
+        // 예약 상태 변경 확인
+        Reservation updatedReservation = reservationRepository.findById(reservationId).orElseThrow();
+        assertThat(updatedReservation.getReservationStatus()).isEqualTo(ReservationStatus.RESERVED);
+
+        // 대기열 상태 변경 확인
+        MemberQueue updatedQueue = memberQueueRepository.findByMemberIdAndConcertId(memberId, concertId).orElseThrow();
+        assertThat(updatedQueue.getTokenStatus()).isEqualTo(TokenStatus.DONE);
+
+        // 결제 내역 저장 확인
+        assertThat(paymentHistoryRepository.findAll()).hasSize(1);
+        PaymentHistory paymentHistory = paymentHistoryRepository.findAll().get(0);
+        assertThat(paymentHistory.getMemberId()).isEqualTo(memberId);
+        assertThat(paymentHistory.getReservationId()).isEqualTo(reservationId);
+        assertThat(paymentHistory.getPaymentType()).isEqualTo(PaymentType.USE);
+        assertThat(paymentHistory.getAmount()).isEqualTo(10000);
+    }
+
+    @Test
+    @DirtiesContext
+    @DisplayName("만료된 예약에 대해 결제를 시도할 경우 예외가 발생한다.")
+    void payExpiredReservationTest() {
+
+        // given
+
+        // 먼저 저장된 예약을 가져옴
+        Reservation reservation = reservationRepository.findById(reservationId).get();
+        Long reservationId = reservation.getId();
+
+        // 만료된 예약 상태로 변경
+        reservation.changeStatus(ReservationStatus.EXPIRED);
+        reservationCommandService.save(reservation);
+
+        // when, then
+        ExpiredReservationException exception = assertThrows(ExpiredReservationException.class, () -> {
+            paymentService.pay(memberId, concertId, reservationId);
+        });
+
+        // then
+        assertEquals("만료된 예약 입니다.", exception.getMessage());
+    }
+}

--- a/src/test/java/com/hanghae/concert/application/ReservationSearchDatesServiceTest.java
+++ b/src/test/java/com/hanghae/concert/application/ReservationSearchDatesServiceTest.java
@@ -1,0 +1,67 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.concert.schedule.*;
+import com.hanghae.concert.domain.concert.schedule.dto.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.queue.*;
+import com.hanghae.concert.domain.reservation.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class ReservationSearchDatesServiceTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private MemberCommandService memberCommandService;
+    @Autowired
+    private MemberQueueCommandService memberQueueCommandService;
+    @Autowired
+    private ConcertCommandService concertCommandService;
+    @Autowired
+    private ConcertScheduleRepository concertScheduleRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트를 위한 초기 데이터 설정
+//        reservationRepository.deleteAll();  // 기존 데이터를 삭제하여 충돌을 방지
+        }
+
+    @Test
+    @Transactional
+    @DisplayName("예약 가능한 날짜를 검색한다.")
+    void searchAvailableDates() {
+        Member member = memberRepository.save(new Member(1L, 0));
+        memberQueueCommandService.save(new MemberQueue(1L, 1L, 1L, "asdf", TokenStatus.ACTIVE, LocalDateTime.now().plusMinutes(5)));
+        Concert concert = concertCommandService.save(new Concert(1L, "제목", 50, 150000, ConcertStatus.AVAILABLE));
+        concertScheduleRepository.save(new ConcertSchedule(1L, 1L, 10, LocalDate.now().plusDays(1).atStartOfDay()));
+        concertScheduleRepository.save(new ConcertSchedule(1L, 1L, 0, LocalDate.now().plusDays(2).atStartOfDay()));
+        concertScheduleRepository.save(new ConcertSchedule(1L, 1L, 8, LocalDate.now().plusDays(3).atStartOfDay()));
+
+
+        Long memberId = member.getId();
+        Long concertId = concert.getId();
+
+        // when
+        List<ConcertScheduleDto> concertScheduleDtos = reservationService.searchAvailableDates(memberId, concertId);
+
+        // then
+        assertThat(concertScheduleDtos)
+                .extracting("startAt")
+                .doesNotContain(LocalDate.now().plusDays(2).atStartOfDay());
+    }
+}

--- a/src/test/java/com/hanghae/concert/application/ReservationSearchSeatsServiceTest.java
+++ b/src/test/java/com/hanghae/concert/application/ReservationSearchSeatsServiceTest.java
@@ -1,0 +1,68 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.concert.seat.*;
+import com.hanghae.concert.domain.concert.seat.dto.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class ReservationSearchSeatsServiceTest {
+
+    @Autowired
+    private ConcertSeatRepository concertSeatRepository;
+    @Autowired
+    private ConcertSeatQueryService concertSeatQueryService;
+
+    @Test
+    @DisplayName("예약 불가능 좌석을 조회한다.")
+    void getImpossibleSeats() {
+
+        //given
+        Long concertScheduleId = 1L;
+
+        concertSeatRepository.saveAll(
+                List.of(
+                        new ConcertSeat(1L, concertScheduleId, 1, true),  // 예약된 좌석
+                        new ConcertSeat(2L, concertScheduleId, 2, false)  // 예약되지 않은 좌석
+                )
+        );
+
+        //when
+        List<ConcertSeatDto> reservedSeats = concertSeatQueryService.getReservedSeats(concertScheduleId);
+
+        //then
+        assertThat(reservedSeats).hasSize(1);
+        assertThat(reservedSeats)
+                .extracting("seatNumber")
+                .contains(1);  // 예약된 좌석만 포함
+    }
+
+    @Test
+    @DisplayName("예약 가능 좌석을 조회하지 않는다.")
+    void getPossibleSeats() {
+
+        //given
+        Long concertScheduleId = 1L;
+
+        concertSeatRepository.saveAll(
+                List.of(
+                        new ConcertSeat(1L, concertScheduleId, 1, true),  // 예약된 좌석
+                        new ConcertSeat(2L, concertScheduleId, 2, false)  // 예약되지 않은 좌석
+                )
+        );
+
+        //when
+        List<ConcertSeatDto> availableSeats = concertSeatQueryService.getReservedSeats(concertScheduleId);
+
+        //then
+        assertThat(availableSeats).hasSize(1);
+        assertThat(availableSeats)
+                .extracting("seatNumber")
+                .doesNotContain(2);  // 예약되지 않은 좌석만 포함
+    }
+}

--- a/src/test/java/com/hanghae/concert/application/ReservationTempReservationServiceTest.java
+++ b/src/test/java/com/hanghae/concert/application/ReservationTempReservationServiceTest.java
@@ -1,0 +1,113 @@
+package com.hanghae.concert.application;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.concert.schedule.*;
+import com.hanghae.concert.domain.concert.seat.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.queue.*;
+import com.hanghae.concert.domain.reservation.*;
+import com.hanghae.concert.domain.reservation.dto.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.test.annotation.*;
+import org.springframework.test.context.jdbc.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class ReservationTempReservationServiceTest {
+
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ConcertRepository concertRepository;
+    @Autowired
+    private ConcertScheduleRepository concertScheduleRepository;
+    @Autowired
+    private ConcertSeatQueryService concertSeatQueryService;
+    @Autowired
+    private ConcertQueryService concertQueryService;
+    @Autowired
+    private MemberQueueRepository memberQueueRepository;
+
+
+    Long memberId;
+    Long memberQueueId;
+    Long concertId;
+    Long concertScheduleId;
+
+    @BeforeEach
+    void setUp() {
+
+
+        Member member = memberRepository.save(new Member(null, 0));
+        memberId = member.getId();
+
+        Concert concert =concertRepository.save(new Concert(1L, "제목", 50, 10000, ConcertStatus.AVAILABLE));
+        concertId = concert.getId();
+
+        MemberQueue memberQueue = memberQueueRepository.save(new MemberQueue(null, memberId, concertId, "asdf", TokenStatus.ACTIVE, LocalDateTime.now().plusMinutes(5)));
+        memberQueueId = memberQueue.getId();
+
+        ConcertSchedule concertSchedule = concertScheduleRepository.save(new ConcertSchedule(1L, concertId, 10, LocalDateTime.now().plusDays(1)));
+        concertScheduleId = concertSchedule.getId();
+    }
+
+    @AfterEach
+    void clear() {
+        memberRepository.deleteAll();
+        concertRepository.deleteAll();
+        memberQueueRepository.deleteAll();
+    }
+
+    @Test
+    @DirtiesContext
+    @DisplayName("임시 좌석으로 예약을 한다.")
+    void tempReservation() {
+
+        // given
+        int seatNumber = 1;
+
+        // when
+        ReservationDto reservationDto = reservationService.tempReservation(memberId, concertId, concertScheduleId, seatNumber);
+
+        // then
+        assertThat(reservationDto).isNotNull();
+        assertThat(reservationDto.concertSeatId()).isNotNull();
+        assertThat(reservationDto.reservationStatus()).isEqualTo(ReservationStatus.TEMP_RESERVED);
+
+        // 잔여 좌석이 감소했는지 검증
+        ConcertSchedule updatedSchedule = concertScheduleRepository.findById(concertScheduleId).get();
+        assertThat(updatedSchedule.getRemainingSeat()).isEqualTo(9);
+
+        // 예약된 좌석이 존재하는지 확인
+        Optional<ConcertSeat> concertSeat = concertSeatQueryService.getConcertSeat(concertScheduleId, seatNumber);
+        assertThat(concertSeat).isPresent();
+        assertThat(concertSeat.get().getSeatNumber()).isEqualTo(seatNumber);
+    }
+
+    @Test
+    @DirtiesContext
+    @DisplayName("잔여 좌석이 0이 되면 콘서트가 SOLD_OUT 상태로 변경된다.")
+    void tempReservationSoldOutTest() {
+
+        // given
+        for (int i = 1; i <= 10; i++) {
+            reservationService.tempReservation(memberId, concertId, concertScheduleId, i);
+        }
+
+        // when
+        reservationService.tempReservation(memberId, concertId, concertScheduleId, 11);
+
+        // then
+        Concert updatedConcert = concertQueryService.getConcertById(concertId);
+        assertThat(updatedConcert.getConcertStatus()).isEqualTo(ConcertStatus.SOLD_OUT);
+    }
+}

--- a/src/test/java/com/hanghae/concert/batch/MemberQueueBatchServiceTest.java
+++ b/src/test/java/com/hanghae/concert/batch/MemberQueueBatchServiceTest.java
@@ -1,0 +1,89 @@
+package com.hanghae.concert.batch;
+
+import com.hanghae.concert.domain.member.queue.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest
+class MemberQueueBatchServiceTest {
+
+
+    @Autowired
+    private MemberQueueBatchService memberQueueBatchService;
+
+    @Autowired
+    private MemberQueueRepository memberQueueRepository;
+
+
+    @Test
+    @DisplayName("만료된 토큰을 삭제한다.")
+    void deleteExpiredToken() {
+
+        //given
+        Long memberId = 1L;
+        Long concertId = 1L;
+        TokenStatus tokenStatus = TokenStatus.ACTIVE;
+        LocalDateTime expiredAt = LocalDateTime.now().minusMinutes(6);  // 만료된 날짜로 설정
+
+        MemberQueue memberQueue = new MemberQueue(
+                null,
+                memberId,
+                concertId,
+                UUID.randomUUID().toString(),
+                tokenStatus,
+                expiredAt
+        );
+
+        // 토큰 저장
+        memberQueueRepository.save(memberQueue);
+
+        Optional<MemberQueue> savedMemberQueue = memberQueueRepository.findById(memberQueue.getId());
+        assertThat(savedMemberQueue).isPresent();
+
+        //when
+        memberQueueBatchService.deleteExpiredToken();
+
+        //then
+        Optional<MemberQueue> deletedMemberQueue = memberQueueRepository.findById(memberQueue.getId());
+        assertThat(deletedMemberQueue).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("만료되지 않은 토큰은 삭제되지 않는다.")
+    void tokenNotDeletedIfNotExpired() {
+
+        //given
+        Long memberId = 1L;
+        Long concertId = 1L;
+        TokenStatus tokenStatus = TokenStatus.ACTIVE;
+        LocalDateTime expiredAt = LocalDateTime.now().plusMinutes(4);
+
+        MemberQueue memberQueue = new MemberQueue(
+                null,
+                memberId,
+                concertId,
+                UUID.randomUUID().toString(),
+                tokenStatus,
+                expiredAt
+        );
+
+        memberQueueRepository.save(memberQueue);
+
+        Optional<MemberQueue> savedMemberQueue = memberQueueRepository.findById(memberQueue.getId());
+        assertThat(savedMemberQueue).isPresent();
+
+        //when
+        memberQueueBatchService.deleteExpiredToken();
+
+        //then
+        Optional<MemberQueue> notDeletedMemberQueue = memberQueueRepository.findById(memberQueue.getId());
+        assertThat(notDeletedMemberQueue).isPresent();
+    }
+}

--- a/src/test/java/com/hanghae/concert/batch/MemberQueueChangeStatusBatchServiceTest.java
+++ b/src/test/java/com/hanghae/concert/batch/MemberQueueChangeStatusBatchServiceTest.java
@@ -1,0 +1,83 @@
+package com.hanghae.concert.batch;
+
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.member.queue.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class MemberQueueChangeStatusBatchServiceTest {
+
+    @Autowired
+    private MemberQueueBatchService memberQueueBatchService;
+
+    @Autowired
+    private MemberQueueRepository memberQueueRepository;
+
+    @Autowired
+    private MemberQueueCommandService memberQueueCommandService;
+
+    @Autowired
+    private ConcertCommandService concertCommandService;
+
+
+    private static Long concertId;
+
+
+    @BeforeEach
+    void setUp() {
+        Concert concert = new Concert(null, "제목", 50, 100000, ConcertStatus.AVAILABLE);
+        concertId = concertCommandService.save(concert).getId();
+
+        for (int i = 0; i < 10; i++) {
+            MemberQueue memberQueue = new MemberQueue(
+                    null,
+                    1L,
+                    concertId,
+                    UUID.randomUUID().toString(),
+                    TokenStatus.WAIT,
+                    null
+            );
+            memberQueueRepository.save(memberQueue);
+        }
+
+        for (int j = 0; j < 40; j++) {
+            MemberQueue memberQueue2 = new MemberQueue(
+                    null,
+                    1L,
+                    concertId,
+                    UUID.randomUUID().toString(),
+                    TokenStatus.ACTIVE,
+                    LocalDateTime.now().plusMinutes(5)
+            );
+            memberQueueRepository.save(memberQueue2);
+        }
+    }
+
+    @Test
+    @DisplayName("WAIT 상태의 토큰을 ACTIVE로 변경하고 만료 시간을 5분 뒤로 설정한다.")
+    void changeTokenStatusWaitToActiveTest() {
+
+        // given
+        LocalDateTime now = LocalDateTime.now();
+
+        // when
+        memberQueueBatchService.changeTokenStatusWaitToActive(now.plusMinutes(5));
+
+        // then
+        List<MemberQueue> updatedQueues = memberQueueRepository.findByConcertIdAndTokenStatus(concertId, TokenStatus.ACTIVE);
+        assertThat(updatedQueues).hasSize(50);  // 50개의 ACTIVE 토큰이 되어야 함
+
+        // 만료 시간이 5분 뒤로 설정되었는지 확인
+        for (MemberQueue queue : updatedQueues) {
+            assertThat(queue.getExpiredAt()).isAfter(now.plusMinutes(4));
+            assertThat(queue.getExpiredAt()).isBefore(now.plusMinutes(6));
+        }
+    }
+}

--- a/src/test/java/com/hanghae/concert/domain/concert/ConcertQueryServiceTest.java
+++ b/src/test/java/com/hanghae/concert/domain/concert/ConcertQueryServiceTest.java
@@ -1,0 +1,93 @@
+package com.hanghae.concert.domain.concert;
+
+import com.hanghae.concert.domain.concert.dto.*;
+import com.hanghae.concert.domain.concert.exception.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConcertQueryServiceTest {
+
+    @Mock
+    private ConcertRepository concertRepository;
+
+    @InjectMocks
+    private ConcertQueryService concertQueryService;
+
+
+    @Test
+    @DisplayName("concertId로 콘서트 정보를 조회한다.")
+    void getConcertById() {
+
+        //given
+        Long concertId = 1L;
+        when(concertRepository.findById(concertId))
+                .thenReturn(
+                        Optional.of(new Concert(concertId, "콘서트명", 50, 150000, ConcertStatus.AVAILABLE))
+                );
+
+        //when
+        ConcertDto concertDto = ConcertDto.of(concertQueryService.getConcertById(concertId));
+
+        //then
+        assertThat(concertDto.concertId()).isEqualTo(concertId);
+    }
+
+    @Test
+    @DisplayName("concertId로 콘서트 정보가 없으면 예외를 던진다.")
+    void getConcertByIdException() {
+
+        //given
+        Long concertId = 1L;
+        when(concertRepository.findById(concertId))
+                .thenReturn(Optional.empty());
+
+        //when
+        ConcertNotFoundException exception = assertThrows(ConcertNotFoundException.class, () -> {
+            concertQueryService.getConcertById(concertId);
+        });
+
+        //then
+        assertEquals("콘서트 정보가 존재하지 않습니다", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("concertId로 콘서트 정보가 있으면 true 로 반환한다.")
+    void getConcertByIdTrue() {
+
+        //given
+        Long concertId = 1L;
+        when(concertRepository.existsById(concertId))
+                .thenReturn(true);
+
+        //when
+        Boolean exists = concertQueryService.existsById(concertId);
+
+        //then
+        assertThat(exists).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("concertId로 콘서트 정보가 없으면 false 로 반환한다.")
+    void getConcertByIdFalse() {
+
+        //given
+        Long concertId = 1L;
+        when(concertRepository.existsById(concertId))
+                .thenReturn(false);
+
+        //when
+        Boolean exists = concertQueryService.existsById(concertId);
+
+        //then
+        assertThat(exists).isEqualTo(false);
+    }
+}

--- a/src/test/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleQueryServiceTest.java
+++ b/src/test/java/com/hanghae/concert/domain/concert/schedule/ConcertScheduleQueryServiceTest.java
@@ -1,0 +1,65 @@
+package com.hanghae.concert.domain.concert.schedule;
+
+import com.hanghae.concert.domain.concert.schedule.dto.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConcertScheduleQueryServiceTest {
+
+    @Mock
+    private ConcertScheduleRepository concertScheduleRepository;
+
+    @InjectMocks
+    private ConcertScheduleQueryService concertScheduleQueryService;
+
+    @Test
+    @DisplayName("예약 가능한 날짜가 있으면 가능한 콘서트 정보를 반환한다.")
+    void getPossibleDates() {
+
+        //given
+        Long concertId = 1L;
+        LocalDateTime startAt = LocalDateTime.now().plusDays(10);
+
+        when(concertScheduleRepository.findAllByConcertId(concertId))
+                .thenReturn(
+                        List.of(new ConcertSchedule(1L, concertId, 50, startAt))
+                );
+
+        //when
+        List<ConcertScheduleDto> availableConcertSchedules = concertScheduleQueryService.getAvailableConcertSchedules(concertId);
+
+        //then
+        assertThat(availableConcertSchedules).hasSize(1)
+                .extracting("concertId", "startAt")
+                .containsExactlyInAnyOrder(
+                        tuple(concertId, startAt)
+                );
+    }
+
+    @Test
+    @DisplayName("예약 가능한 날짜가 없으면 빈 리스트를 반환한다.")
+    void getImpossibleDates() {
+
+        //given
+        Long concertId = 1L;
+        LocalDateTime startAt = LocalDateTime.now().plusDays(10);
+
+        when(concertScheduleRepository.findAllByConcertId(concertId))
+                .thenReturn(List.of());
+
+        //when
+        List<ConcertScheduleDto> availableConcertSchedules = concertScheduleQueryService.getAvailableConcertSchedules(concertId);
+
+        //then
+        assertThat(availableConcertSchedules).hasSize(0);
+    }
+}

--- a/src/test/java/com/hanghae/concert/domain/concert/seat/ConcertSeatQueryServiceTest.java
+++ b/src/test/java/com/hanghae/concert/domain/concert/seat/ConcertSeatQueryServiceTest.java
@@ -1,0 +1,73 @@
+package com.hanghae.concert.domain.concert.seat;
+
+import com.hanghae.concert.domain.concert.seat.dto.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConcertSeatQueryServiceTest {
+
+    @Mock
+    private ConcertSeatRepository concertSeatRepository;
+
+    @InjectMocks
+    private ConcertSeatQueryService concertSeatQueryService;
+
+    @Test
+    @DisplayName("예약된 좌석을 조회하면, 상태가 true인 좌석만 조회된다.")
+    void getReservedSeats() {
+
+        //given
+        Long concertScheduleId = 1L;
+
+        when(concertSeatRepository.findAllByConcertScheduleId(concertScheduleId))
+                .thenReturn(
+                        List.of(
+                                new ConcertSeat(1L, concertScheduleId, 1, true),
+                                new ConcertSeat(1L, concertScheduleId, 2, false),
+                                new ConcertSeat(1L, concertScheduleId, 3, true)
+                        )
+                );
+
+        //when
+        List<ConcertSeatDto> reservedSeats = concertSeatQueryService.getReservedSeats(concertScheduleId);
+
+        // then
+        assertThat(reservedSeats)
+                .hasSize(2)  // reservedSeats의 크기가 2인지 확인
+                .extracting("seatNumber")  // seatNumber 필드를 추출
+                .containsExactlyInAnyOrder(1, 3);  // 추출된 seatNumber 값들이 1과 3인지 확인
+    }
+
+    @Test
+    @DisplayName("예약된 좌석을 조회하면, 상태가 false 인 좌석은 조회되지 않는다.")
+    void getNotReservedSeats() {
+
+        //given
+        Long concertScheduleId = 1L;
+
+        when(concertSeatRepository.findAllByConcertScheduleId(concertScheduleId))
+                .thenReturn(
+                        List.of(
+                                new ConcertSeat(1L, concertScheduleId, 1, true),
+                                new ConcertSeat(1L, concertScheduleId, 2, false),
+                                new ConcertSeat(1L, concertScheduleId, 3, true)
+                        )
+                );
+
+        //when
+        List<ConcertSeatDto> reservedSeats = concertSeatQueryService.getReservedSeats(concertScheduleId);
+
+        // then
+        assertThat(reservedSeats)
+                .extracting("seatNumber")
+                .doesNotContain(2);
+    }
+}

--- a/src/test/java/com/hanghae/concert/domain/member/MemberCommandServiceTest.java
+++ b/src/test/java/com/hanghae/concert/domain/member/MemberCommandServiceTest.java
@@ -1,0 +1,67 @@
+package com.hanghae.concert.domain.member;
+
+import com.hanghae.concert.domain.payment.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class MemberCommandServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberCommandService memberCommandService;
+
+    @Test
+    @DisplayName("충전을 하면 유저의 잔액이 충전된다.")
+    void chargeBalance() {
+
+        //given
+        Long memberId = 1L;
+        int init = 0;
+        int balance = 1000;
+        int result = 1000;
+        PaymentType paymentType = PaymentType.CHARGE;
+
+        Member member = new Member(memberId, init);
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        //when
+        memberCommandService.updateBalance(memberId, balance, paymentType);
+
+        // then
+        verify(memberRepository).save(member);
+        assertEquals(result, member.getBalance());
+    }
+
+    @Test
+    @DisplayName("사용을 하면 유저의 잔액이 차감된다.")
+    void useBalance() {
+
+        //given
+        Long memberId = 1L;
+        int init = 1000;
+        int balance = 500;
+        int result = 500;
+        PaymentType paymentType = PaymentType.USE;
+
+        Member member = new Member(memberId, init);
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        //when
+        memberCommandService.updateBalance(memberId, balance, paymentType);
+
+        // then
+        verify(memberRepository).save(member);
+        assertEquals(result, member.getBalance());
+    }
+}

--- a/src/test/java/com/hanghae/concert/domain/member/MemberQueryServiceTest.java
+++ b/src/test/java/com/hanghae/concert/domain/member/MemberQueryServiceTest.java
@@ -1,0 +1,14 @@
+package com.hanghae.concert.domain.member;
+
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberQueryServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+}

--- a/src/test/java/com/hanghae/concert/domain/member/MemberTest.java
+++ b/src/test/java/com/hanghae/concert/domain/member/MemberTest.java
@@ -1,0 +1,77 @@
+package com.hanghae.concert.domain.member;
+
+import com.hanghae.concert.domain.payment.*;
+import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("잔고 충전할 때 마이너스 또는 0원을 충전하면 에러가 발생한다.")
+    void chargeMinusAndZeroException() {
+
+        //given
+        Member member = new Member(null, 0);
+
+        //when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            member.changeBalance(0, PaymentType.CHARGE);
+        });
+
+        //then
+        assertEquals("마이너스 금액 또는 0원을 충전할 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("잔고 사용할 때 마이너스 또는 0원을 사용하면 에러가 발생한다.")
+    void useMinusAndZeroException() {
+
+        //given
+        Member member = new Member(null, 0);
+
+        //when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            member.changeBalance(0, PaymentType.USE);
+        });
+
+        //then
+        assertEquals("마이너스 금액 또는 0원을 사용할 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("잔고가 부족하면 예외가 발생한다.")
+    void notEnough() {
+
+        int useAmount = 1;
+
+        //given
+        Member member = new Member(null, 0);
+
+        //when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            member.changeBalance(useAmount, PaymentType.USE);
+        });
+
+        //then
+        assertEquals("차감할 포인트가 부족합니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("잔고 충전할 때 0원 이상을 충전할 수 있다.")
+    void chargeOk() {
+
+        int chartAmount = 10000;
+
+        //given
+        Member member = new Member(null, 0);
+
+        //when
+        member.changeBalance(chartAmount, PaymentType.CHARGE);
+
+        //then
+        assertThat(member.getBalance()).isEqualTo(chartAmount);
+    }
+
+}

--- a/src/test/java/com/hanghae/concert/domain/member/queue/MemberQueueQueryServiceTest.java
+++ b/src/test/java/com/hanghae/concert/domain/member/queue/MemberQueueQueryServiceTest.java
@@ -1,0 +1,57 @@
+package com.hanghae.concert.domain.member.queue;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberQueueQueryServiceTest {
+
+    @Mock
+    private MemberQueueRepository memberQueueRepository;
+
+    @InjectMocks
+    private MemberQueueQueryService memberQueueQueryService;
+
+    //todo review 이게 의미 있는 테스트인가..
+
+    @Test
+    @DisplayName("대기열에 정원 이하의 Active 토큰이 존재한다면 True 를 반환한다.")
+    void loeCapacityThenTrue() {
+
+        //given
+        Long concertId = 1L;
+        Integer capacity = 50;
+        Integer cnt = 51;
+
+        when(memberQueueRepository.countByConcertIdAndTokenStatus(concertId, TokenStatus.ACTIVE)).thenReturn(cnt);
+
+        //when
+        Boolean overCapacity = memberQueueQueryService.isActiveTokenOverCapacity(concertId, capacity);
+
+        //then
+        assertThat(overCapacity).isTrue();
+    }
+
+    @Test
+    @DisplayName("대기열에 정원 이하의 Active 토큰이 존재한다면 False 를 반환한다.")
+    void loeCapacityThenFalse() {
+
+        //given
+        Long concertId = 1L;
+        Integer capacity = 50;
+        Integer cnt = 49;
+
+        when(memberQueueRepository.countByConcertIdAndTokenStatus(concertId, TokenStatus.ACTIVE)).thenReturn(cnt);
+
+        //when
+        Boolean overCapacity = memberQueueQueryService.isActiveTokenOverCapacity(concertId, capacity);
+
+        //then
+        assertThat(overCapacity).isFalse();
+    }
+}

--- a/src/test/java/com/hanghae/concert/domain/member/queue/MemberQueueServiceIntegrationTest.java
+++ b/src/test/java/com/hanghae/concert/domain/member/queue/MemberQueueServiceIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.hanghae.concert.domain.member.queue;
+
+import com.hanghae.concert.application.*;
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.dto.*;
+import com.hanghae.concert.domain.member.queue.dto.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.transaction.annotation.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // 테스트 인스턴스를 클래스당 1개로 유지
+@SpringBootTest
+class MemberQueueServiceIntegrationTest {
+
+    @Autowired
+    private MemberCommandService memberCommandService;
+
+    @Autowired
+    private ConcertCommandService concertCommandService;
+
+    @Autowired
+    private MemberQueueService memberQueueService;
+
+    private Long memberId;
+
+    private Long concertId;
+
+    @BeforeAll
+    void setUp() {
+
+        MemberDto memberDto = MemberDto.of(memberCommandService.initMember(
+                new Member(1L, 0)
+        ));
+        memberId = memberDto.id();
+
+        Concert concert = concertCommandService.save(
+                new Concert(
+                        null,
+                        "콘서트 제목",
+                        50,
+                        150000,
+                        ConcertStatus.AVAILABLE
+                )
+        );
+        concertId = concert.getId();
+    }
+
+    @Transactional
+    @DisplayName("대기열에 정원 이하의 Active 토큰만 존재한다면 Active 토큰이 발급된다.")
+    @Test
+    void getActiveToken() {
+
+        // given
+        Long memberId = 1L;
+
+        // when
+        MemberQueueDto memberQueueDto = memberQueueService.createToken(memberId, concertId);
+
+        // then
+        assertThat(memberQueueDto.tokenStatus()).isEqualTo(TokenStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("대기열에 정원 초과의 Active 토큰이 존재한다면 Wait 토큰이 발급된다.")
+    void getWaitToken() {
+
+        // given
+        for (long memberId = 1L; memberId <= 50L; memberId++) {
+            memberCommandService.initMember(new Member(memberId, 0));
+            memberQueueService.createToken(memberId, concertId);
+        }
+        Long waitMember = 51L;
+        memberCommandService.initMember(new Member(waitMember, 0));
+
+        // when
+        MemberQueueDto memberQueueDto = memberQueueService.createToken(waitMember, concertId);
+
+        // then
+        assertThat(memberQueueDto.tokenStatus()).isEqualTo(TokenStatus.WAIT);
+    }
+}

--- a/src/test/java/com/hanghae/concert/domain/member/queue/MemberQueueServiceTest.java
+++ b/src/test/java/com/hanghae/concert/domain/member/queue/MemberQueueServiceTest.java
@@ -1,0 +1,107 @@
+package com.hanghae.concert.domain.member.queue;
+
+import com.hanghae.concert.application.*;
+import com.hanghae.concert.domain.concert.*;
+import com.hanghae.concert.domain.member.*;
+import com.hanghae.concert.domain.member.queue.dto.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberQueueServiceTest {
+
+    @Mock
+    private MemberQueryService memberQueryService;
+
+    @Mock
+    private ConcertQueryService concertQueryService;
+
+    @Mock
+    private MemberQueueCommandService memberQueueCommandService;
+
+    @Mock
+    private MemberQueueQueryService memberQueueQueryService;
+
+    @InjectMocks
+    private MemberQueueService memberQueueService;
+
+    private Long memberId;
+    private Long concertId;
+    private Integer capacity;
+    private Concert concert;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+
+        memberId = 1L;
+        concertId = 1L;
+        capacity = 50;
+
+        concert = new Concert(
+                concertId,
+                "콘서트 제목",
+                capacity,
+                150000,
+                ConcertStatus.AVAILABLE
+        );
+
+        member = new Member(memberId, 0);
+
+        when(concertQueryService.getConcertById(concertId)).thenReturn(concert);
+        when(memberQueryService.existsMemberById(memberId)).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("대기열에 정원 이하의 Active 토큰만 존재한다면 Active 토큰이 발급된다.")
+    void getActiveToken() {
+
+        // given
+        MemberQueue mockActiveMemberQueue = createMockMemberQueue(TokenStatus.ACTIVE, LocalDateTime.now().plusMinutes(5));
+
+        when(memberQueueQueryService.isActiveTokenOverCapacity(concertId, capacity)).thenReturn(false);
+        when(memberQueueCommandService.save(any(MemberQueue.class))).thenReturn(mockActiveMemberQueue);
+
+        // when
+        MemberQueueDto memberQueueDto = memberQueueService.createToken(memberId, concertId);
+
+        // then
+        assertThat(memberQueueDto.tokenStatus()).isEqualTo(TokenStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("대기열에 정원 초과의 Active 토큰이 존재한다면 WAIT 토큰이 발급된다.")
+    void getWaitToken() {
+
+        // given
+        MemberQueue mockWaitMemberQueue = createMockMemberQueue(TokenStatus.WAIT, null);
+
+        when(memberQueueQueryService.isActiveTokenOverCapacity(concertId, capacity)).thenReturn(true);
+        when(memberQueueCommandService.save(any(MemberQueue.class))).thenReturn(mockWaitMemberQueue);
+
+        // when
+        MemberQueueDto memberQueueDto = memberQueueService.createToken(memberId, concertId);
+
+        // then
+        assertThat(memberQueueDto.tokenStatus()).isEqualTo(TokenStatus.WAIT);
+    }
+
+    private MemberQueue createMockMemberQueue(TokenStatus tokenStatus, LocalDateTime expiredAt) {
+        return new MemberQueue(
+                1L,
+                memberId,
+                concertId,
+                UUID.randomUUID().toString(),
+                tokenStatus,
+                expiredAt
+        );
+    }
+}


### PR DESCRIPTION
# 구현 기능
    - 유저 토큰 발급 API
    - 예약 가능 날짜 / 좌석 API
    - 좌석 예약 요청 API
    - 잔액 충전 / 조회 API
    - 결제 API
    - application 하위 서비스(유즈케이스)의 통합테스트
    - batch 하위에 대기열 상태 관리 스케쥴러
    - domain 하위 서비스의 단위 테스트
    - 동시성 제어는 못함

# 리뷰 포인트
 - (f80ef9de118a81f52af830f428687052f044d922)대기열 상태 변경 정책을 콘서트의 정원 이내로 제한하여 로직 복잡도가 높아짐
 - (7145957a5d48ca480e4fe8ba0d295665ef5598c9)대기열 만료자 삭제 배치가 1분마다 돌고, 상태 변경 배치가 5분마다 도는데 이 배치 또한 동시성 제어가 필요할까요? 스케쥴러의 task를 각각 구현해 뒀습니다.