### PR TITLE
step9 인터셉터

### DIFF
--- a/concert.http
+++ b/concert.http
@@ -1,0 +1,56 @@
+### 예약 가능 날짜 조회
+### Create a new concert
+POST http://localhost:8080/concert
+Content-Type: application/json
+Authorization: asdfasdf
+
+{
+  "title": "heo jae concert",
+  "capacity": 50,
+  "seatPrice": 500000,
+  "concertStatus": "AVAILABLE",
+  "startAt": "2024-11-01T19:00:00"
+}
+
+
+
+### 예약 가능 날짜 조회
+@concertId = 1
+@memberId = 1
+GET http://localhost:8080/concert/{{concertId}}/schedules?memberId={{memberId}}
+Authorization: asdfasdf
+
+
+
+### 예약이 완료된 조회
+GET http://localhost:8080/concert/1/schedule/2/seats?memberId=1
+Authorization: asdfasdf
+
+
+
+### 좌석 예약
+POST http://localhost:8080/concert/reservation
+Content-Type: application/json
+Authorization: asdfasdf
+
+{
+  "memberId": 1,
+  "concertId": 1,
+  "concertScheduleId": 1,
+  "seatNumber": 1
+}
+
+
+### 결제
+POST http://localhost:8080/concert/pay
+Content-Type: application/json
+Authorization: asdfasdf
+
+{
+  "memberId": 1,
+  "concertId": 1,
+  "reservationId": 1
+}
+
+
+

--- a/member.http
+++ b/member.http
@@ -1,0 +1,27 @@
+### 유저 생성
+POST http://localhost:8080/member
+
+
+
+### 특정 유저 조회
+@memberId1 = 1
+
+GET http://localhost:8080/member/balance?memberId={{memberId1}}
+Authorization: asdfasdf
+
+
+
+### 특정 유저의 잔액 사용/충전
+@paymentType = CHARGE
+#@paymentType = USE
+
+POST http://localhost:8080/member/balance
+Authorization: asdfasdf
+Content-Type: application/json
+
+{
+  "memberId": 1,
+  "amount": 1000,
+  "paymentType": "{{paymentType}}"
+}
+

--- a/memberQueue.http
+++ b/memberQueue.http
@@ -1,0 +1,17 @@
+### 대기열 생성
+POST http://localhost:8080/queue
+Authorization: asdfasdf
+Content-Type: application/json
+
+{
+  "memberId": 1,
+  "concertId": 1
+}
+
+
+### 나의 대기 순번 조회 API
+// WAIT 상태가 아닐 경우, null 응답
+// WAIT 상태일 때는 나를 포함한 대기자 수 응답
+GET http://localhost:8080/queue/my-turn
+Authorization: asdfasdf
+

--- a/paymentHistory.http
+++ b/paymentHistory.http
@@ -1,0 +1,27 @@
+### 유저 생성
+POST http://localhost:8080/member
+
+
+
+### 특정 유저 조회
+@memberId1 = 1
+
+GET http://localhost:8080/member/balance?memberId={{memberId1}}
+Authorization: asdfasdf
+
+
+
+### 특정 유저의 잔액 사용/충전
+@paymentType = CHARGE
+#@paymentType = USE
+
+POST http://localhost:8080/member/balance
+Authorization: asdfasdf
+Content-Type: application/json
+
+{
+  "memberId": 1,
+  "amount": 1000,
+  "paymentType": "{{paymentType}}"
+}
+

--- a/src/main/java/com/hanghae/concert/api/common/config/Interceptor.java
+++ b/src/main/java/com/hanghae/concert/api/common/config/Interceptor.java
@@ -1,0 +1,42 @@
+package com.hanghae.concert.api.common.config;
+
+import com.hanghae.concert.domain.member.queue.*;
+import com.hanghae.concert.domain.member.queue.exception.*;
+import jakarta.security.auth.message.*;
+import jakarta.servlet.http.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+import org.springframework.util.*;
+import org.springframework.web.servlet.*;
+
+@Component
+@RequiredArgsConstructor
+public class Interceptor implements HandlerInterceptor {
+
+    private final static String AUTHORIZATION = "Authorization";
+
+    private final MemberQueueRepository memberQueueRepository;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) throws Exception {
+
+        String token = request.getHeader(AUTHORIZATION);
+
+        if (!StringUtils.hasText(token)) {
+            throw new AuthException("토큰이 존재하지 않습니다.");
+        }
+
+        MemberQueue memberQueue = memberQueueRepository.findByToken(token)
+                .orElseThrow(MemberQueueNotFoundException::new);
+
+        if (memberQueue.isStatusActive()) {
+            return true;
+        } else {
+            throw new AuthException("접근 불가능한 토큰입니다.");
+        }
+    }
+}

--- a/src/main/java/com/hanghae/concert/api/common/config/WebConfig.java
+++ b/src/main/java/com/hanghae/concert/api/common/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.hanghae.concert.api.common.config;
+
+import org.springframework.context.annotation.*;
+import org.springframework.web.servlet.config.annotation.*;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final Interceptor interceptor;
+
+    public WebConfig(Interceptor interceptor) {
+        this.interceptor = interceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+
+        registry.addInterceptor(interceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(
+                        "/**",
+                        "/member",
+                        "/queue",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**"
+                );
+    }
+}


### PR DESCRIPTION
# 구현 내용
-(71b45f4e64724b9f49119fca76f0a64f6d7bd9ba) .http 파일의 http 요청 
- (f2f60b2039167b0af80550ce88cf98f8ea2f002f) 인터셉터

# 리뷰포인트
- 인터셉터에서 토큰으로 대기열 객체를 찾아서 검증하는데,  API로 넘겨주지 못하니까 API에 @RequestHeader로 선언된 토큰을 비지니스 로직에서 또 token으로 대기열 객체를 찾아야 하는 비효율적인 작업이 수행됩니다. 이런 생각이 맞는걸까요?
(그래서 모든 API에서 `@RequestHeader` 로 token 선언한 부분을 모두 제거 했습니다.)

-  해당 프로젝트는 JWT를 활용하지 않고, UUID를 단순히 대기열 테이블에 저장하고 있습니다.
- 이때, 인터셉터에서 UUID를 검증하여 active 상태를 확인하는 작업을 합니다.